### PR TITLE
Add 7874i support

### DIFF
--- a/total_connect_client/TotalConnectClient.py
+++ b/total_connect_client/TotalConnectClient.py
@@ -13,7 +13,8 @@ VALID_DEVICES = ['Security Panel',
                  'ILP5',
                  'LTE-XV',
                  'GSMX4G',
-                 'GSMVLP5-4G'
+                 'GSMVLP5-4G',
+                 '7874i',
                  ]
 
 class AuthenticationError(Exception):


### PR DESCRIPTION
Add 7874i support to total connect client. Currently the client supports a few devices. The 7874i is a wifi device used with various Vista-type panels.