### PR TITLE
Fixed get_armed_status function

### DIFF
--- a/total_connect_client/TotalConnectClient.py
+++ b/total_connect_client/TotalConnectClient.py
@@ -276,7 +276,7 @@ class TotalConnectClient:
 
         self.get_panel_meta_data(location_name)
 
-        alarm_code = self.panel_meta_data['PanelMetadataAndStatus']['Partitions']['PartitionInfo'][0]['ArmingState']
+        alarm_code = self._panel_meta_data['PanelMetadataAndStatus']['Partitions']['PartitionInfo'][0]['ArmingState']
 
         return alarm_code
 


### PR DESCRIPTION
With reference to: https://github.com/home-assistant/home-assistant/issues/22229

total-connect-client has a bug in the get_armed_status() function.

Can you please merge this PR and release to Pypi?