### PR TITLE
Fix #80 and #81

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 setup(
     name="total_connect_client",
     py_modules=["total_connect_client"],
-    version="0.55",
+    version="0.55.1",
     description="Interact with Total Connect 2 alarm systems",
     author="Craig J. Midwinter",
     author_email="craig.j.midwinter@gmail.com",

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,26 @@
+"""Common test code."""
+from unittest.mock import patch
+
+import TotalConnectClient
+from const import (
+    RESPONSE_AUTHENTICATE,
+    RESPONSE_DISARMED,
+    RESPONSE_GET_ZONE_DETAILS_SUCCESS,
+)
+
+
+def create_client():
+    """Return a TotalConnectClient that appears to be logged in."""
+    RESPONSES = [
+        RESPONSE_AUTHENTICATE,
+        RESPONSE_GET_ZONE_DETAILS_SUCCESS,
+        RESPONSE_DISARMED,
+    ]
+
+    with patch("zeep.Client", autospec=True), patch(
+        "TotalConnectClient.TotalConnectClient.request", side_effect=RESPONSES,
+    ) as mock_request:
+        client = TotalConnectClient.TotalConnectClient("username", "password")
+        assert mock_request.call_count == 3
+
+    return client

--- a/tests/const.py
+++ b/tests/const.py
@@ -1,4 +1,5 @@
 """Testing constants."""
+import TotalConnectClient
 
 PASSWORD_BAD = "none"
 USERNAME_BAD = "none"
@@ -10,4 +11,108 @@ LOCATION_INFO_BASIC_NORMAL = {
     "PhotoURL": "http://www.example.com/some/path/to/file.jpg",
     "LocationModuleFlags": "Security=1,Video=0,Automation=0,GPS=0,VideoPIR=0",
     "DeviceList": None,
+}
+
+LOCATIONS = {"LocationInfoBasic": [LOCATION_INFO_BASIC_NORMAL]}
+
+MODULE_FLAGS = "Some=0,Fake=1,Flags=2"
+
+USER = {
+    "UserID": "1234567",
+    "Username": "username",
+    "UserFeatureList": "Master=0,User Administration=0,Configuration Administration=0",
+}
+
+
+ZONE_NORMAL = {
+    "ZoneID": "1",
+    "ZoneDescription": "Normal",
+    "ZoneStatus": TotalConnectClient.ZONE_STATUS_NORMAL,
+    "PartitionId": "1",
+}
+
+ZONE_INFO = []
+ZONE_INFO.append(ZONE_NORMAL)
+ZONES = {"ZoneInfo": ZONE_INFO}
+
+ZONE_STATUS_NORMAL = {
+    "PartitionId": "1",
+    "Batterylevel": "-1",
+    "Signalstrength": "-1",
+    "zoneAdditionalInfo": None,
+    "ZoneID": "1",
+    "ZoneStatus": TotalConnectClient.ZONE_STATUS_NORMAL,
+    "ZoneTypeId": TotalConnectClient.ZONE_TYPE_SECURITY,
+    "CanBeBypassed": 1,
+    "ZoneFlags": None,
+}
+
+ZONE_STATUS_INFO = []
+ZONE_STATUS_INFO.append(ZONE_STATUS_NORMAL)
+
+ZONES = {"ZoneStatusInfoWithPartitionId": ZONE_STATUS_INFO}
+
+ZONE_STATUS = {"Zones": ZONES}
+
+RESPONSE_GET_ZONE_DETAILS_SUCCESS = {
+    "ResultCode": 0,
+    "ResultData": "Success",
+    "ZoneStatus": ZONE_STATUS,
+}
+
+PARTITION_DISARMED = {
+    "PartitionID": "1",
+    "ArmingState": TotalConnectClient.TotalConnectLocation.DISARMED,
+}
+
+PARTITION_ARMED_STAY = {
+    "PartitionID": "1",
+    "ArmingState": TotalConnectClient.TotalConnectLocation.ARMED_STAY,
+}
+
+PARTITION_ARMED_AWAY = {
+    "PartitionID": "1",
+    "ArmingState": TotalConnectClient.TotalConnectLocation.ARMED_AWAY,
+}
+
+PARTITION_INFO_DISARMED = {}
+PARTITION_INFO_DISARMED[0] = PARTITION_DISARMED
+
+PARTITION_INFO_ARMED_STAY = {}
+PARTITION_INFO_ARMED_STAY[0] = PARTITION_ARMED_STAY
+
+PARTITION_INFO_ARMED_AWAY = {}
+PARTITION_INFO_ARMED_AWAY[0] = PARTITION_ARMED_AWAY
+
+PARTITIONS_DISARMED = {"PartitionInfo": PARTITION_INFO_DISARMED}
+PARTITIONS_ARMED_STAY = {"PartitionInfo": PARTITION_INFO_ARMED_STAY}
+PARTITIONS_ARMED_AWAY = {"PartitionInfo": PARTITION_INFO_ARMED_AWAY}
+
+METADATA_DISARMED = {
+    "Partitions": PARTITIONS_DISARMED,
+    "Zones": ZONES,
+    "PromptForImportSecuritySettings": False,
+    "IsInACLoss": False,
+    "IsCoverTampered": False,
+    "Bell1SupervisionFailure": False,
+    "Bell2SupervisionFailure": False,
+    "IsInLowBattery": False,
+}
+
+METADATA_ARMED_STAY = METADATA_DISARMED.copy()
+METADATA_ARMED_STAY["Partitions"] = PARTITIONS_ARMED_STAY
+
+METADATA_ARMED_AWAY = METADATA_DISARMED.copy()
+METADATA_ARMED_AWAY["Partitions"] = PARTITIONS_ARMED_AWAY
+
+RESPONSE_DISARMED = {"ResultCode": 0, "PanelMetadataAndStatus": METADATA_DISARMED}
+RESPONSE_ARMED_STAY = {"ResultCode": 0, "PanelMetadataAndStatus": METADATA_ARMED_STAY}
+RESPONSE_ARMED_AWAY = {"ResultCode": 0, "PanelMetadataAndStatus": METADATA_ARMED_AWAY}
+
+RESPONSE_AUTHENTICATE = {
+    "ResultCode": 0,
+    "SessionID": 1,
+    "Locations": LOCATIONS,
+    "ModuleFlags": MODULE_FLAGS,
+    "UserInfo": USER,
 }

--- a/tests/test_client_arm_disarm.py
+++ b/tests/test_client_arm_disarm.py
@@ -3,8 +3,8 @@
 import unittest
 from unittest.mock import Mock, patch
 
-from TotalConnectClient import TotalConnectClient as tcc
 from const import PASSWORD_BAD, USERNAME_BAD
+from TotalConnectClient import TotalConnectClient as tcc
 
 
 class FakeClient(tcc):

--- a/tests/test_get_panel_meta_data.py
+++ b/tests/test_get_panel_meta_data.py
@@ -1,0 +1,54 @@
+"""Test total_connect_client."""
+
+import unittest
+from unittest.mock import patch
+
+from common import create_client
+from const import LOCATION_INFO_BASIC_NORMAL, RESPONSE_ARMED_AWAY, RESPONSE_DISARMED
+
+RESPONSE_DISARMED_NONE = {"ResultCode": 0}
+
+
+class TestTotalConnectClient(unittest.TestCase):
+    """Test TotalConnectClient."""
+
+    def setUp(self):
+        """Test setup."""
+        self.client = create_client()
+        self.location_id = LOCATION_INFO_BASIC_NORMAL["LocationID"]
+
+    def tearDown(self):
+        """Test cleanup."""
+        self.client = None
+
+    def tests_get_panel_meta_data_normal(self):
+        """Test get_panel_meta_data() with a normal response."""
+
+        RESPONSES = [RESPONSE_ARMED_AWAY, RESPONSE_DISARMED]
+        with patch(
+            "TotalConnectClient.TotalConnectClient.request", side_effect=RESPONSES,
+        ):
+            # should start disarmed
+            assert self.client.locations[self.location_id].is_disarmed() is True
+
+            # first response shows armed_away
+            self.client.get_panel_meta_data(self.location_id)
+            assert self.client.locations[self.location_id].is_armed_away() is True
+
+            # second response shows disarmed
+            self.client.get_panel_meta_data(self.location_id)
+            assert self.client.locations[self.location_id].is_disarmed() is True
+
+    def tests_get_panel_meta_data_none(self):
+        """Test get_panel_meta_data() with an empty PanelMetadataAndStatus response."""
+
+        RESPONSES = [RESPONSE_DISARMED_NONE]
+        with patch(
+            "TotalConnectClient.TotalConnectClient.request", side_effect=RESPONSES,
+        ):
+            # should start disarmed
+            assert self.client.locations[self.location_id].is_disarmed() is True
+
+            # first response gives empty status...should remain the same
+            self.client.get_panel_meta_data(self.location_id)
+            assert self.client.locations[self.location_id].is_disarmed() is True

--- a/tests/test_get_zone_details.py
+++ b/tests/test_get_zone_details.py
@@ -3,9 +3,8 @@
 import unittest
 
 import TotalConnectClient
-from TotalConnectClient import TotalConnectLocation as tcl
-
 from const import LOCATION_INFO_BASIC_NORMAL, PASSWORD_BAD, USERNAME_BAD
+from TotalConnectClient import TotalConnectLocation as tcl
 
 ZONE_NORMAL = {
     "PartitionId": "1",

--- a/tests/test_total_connect_client.py
+++ b/tests/test_total_connect_client.py
@@ -3,7 +3,6 @@
 import unittest
 
 import TotalConnectClient
-
 from const import PASSWORD_BAD, USERNAME_BAD
 
 

--- a/tests/test_total_connect_location.py
+++ b/tests/test_total_connect_location.py
@@ -3,42 +3,7 @@
 import unittest
 
 import TotalConnectClient
-
-from const import LOCATION_INFO_BASIC_NORMAL
-
-PARTITION_DISARMED = {
-    "PartitionID": "1",
-    "ArmingState": TotalConnectClient.TotalConnectLocation.DISARMED,
-}
-
-PARTITION_INFO_DISARMED = {}
-PARTITION_INFO_DISARMED[0] = PARTITION_DISARMED
-
-PARTITIONS = {"PartitionInfo": PARTITION_INFO_DISARMED}
-
-ZONE_NORMAL = {
-    "ZoneID": "1",
-    "ZoneDescription": "Normal",
-    "ZoneStatus": TotalConnectClient.ZONE_STATUS_NORMAL,
-    "PartitionId": "1",
-}
-
-ZONE_INFO = {}
-ZONE_INFO[0] = ZONE_NORMAL
-ZONES = {"ZoneInfo": ZONE_INFO}
-
-METADATA_NORMAL = {
-    "Partitions": PARTITIONS,
-    "Zones": ZONES,
-    "PromptForImportSecuritySettings": False,
-    "LastUpdatedTimestampTicks": 637161937050000000,
-    "ConfigurationSequenceNumber": 1,
-    "IsInACLoss": False,
-    "IsCoverTampered": False,
-    "Bell1SupervisionFailure": False,
-    "Bell2SupervisionFailure": False,
-    "IsInLowBattery": False,
-}
+from const import LOCATION_INFO_BASIC_NORMAL, METADATA_DISARMED
 
 
 class TestTotalConnectLocation(unittest.TestCase):
@@ -50,8 +15,7 @@ class TestTotalConnectLocation(unittest.TestCase):
         self.location_normal = TotalConnectClient.TotalConnectLocation(
             LOCATION_INFO_BASIC_NORMAL, self
         )
-        """having trouble setting up test structure for METADATA_NORMAL"""
-        #        self.location_normal.set_status(METADATA_NORMAL)
+        self.location_normal.set_status(METADATA_DISARMED)
 
     def tearDown(self):
         """Tear down."""
@@ -81,7 +45,7 @@ class TestTotalConnectLocation(unittest.TestCase):
         """Normal zone."""
         self.assertFalse(self.location_normal.is_arming())
         self.assertFalse(self.location_normal.is_disarming())
-        #        self.assertTrue(self.location_normal.is_disarmed())
+        self.assertTrue(self.location_normal.is_disarmed())
         self.assertFalse(self.location_normal.is_armed_away())
         self.assertFalse(self.location_normal.is_armed_custom_bypass())
         self.assertFalse(self.location_normal.is_armed_home())
@@ -91,3 +55,9 @@ class TestTotalConnectLocation(unittest.TestCase):
         self.assertFalse(self.location_normal.is_triggered_fire())
         self.assertFalse(self.location_normal.is_triggered_gas())
         self.assertFalse(self.location_normal.is_triggered())
+
+    def tests_set_status_none(self):
+        """Test set_status with None passed in."""
+        self.assertTrue(self.location_normal.is_disarmed())
+        self.assertFalse(self.location_normal.set_status(None))
+        self.assertTrue(self.location_normal.is_disarmed())

--- a/total_connect_client/info.py
+++ b/total_connect_client/info.py
@@ -1,7 +1,8 @@
 """Test your system from the command line."""
 
-import sys
 import logging
+import sys
+
 import TotalConnectClient
 
 logging.basicConfig(filename="test.log", level=logging.DEBUG)

--- a/total_connect_client/live_test_auto_bypass.py
+++ b/total_connect_client/live_test_auto_bypass.py
@@ -1,8 +1,9 @@
 """Test your system from the command line."""
 
-import sys
 import logging
+import sys
 from pprint import pprint
+
 import TotalConnectClient
 
 logging.basicConfig(filename="test.log", level=logging.DEBUG)


### PR DESCRIPTION
Better handles result code -4502 Command Failed when trying to arm the system with a zone faulted. #81

Error checking for an empty PanelMetaDataAndStatus when updating status, and for None passed to Location.set_status(). #80  Added tests.

Various minor updates from running `black` and `isort` on the code.
