### PR TITLE
Move soap

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 setup(
     name="total_connect_client",
     py_modules=["total_connect_client"],
-    version="0.57",
+    version="0.58",
     description="Interact with Total Connect 2 alarm systems",
     author="Craig J. Midwinter",
     author_email="craig.j.midwinter@gmail.com",

--- a/tests/common.py
+++ b/tests/common.py
@@ -17,7 +17,7 @@ def create_client():
         RESPONSE_DISARMED,
     ]
 
-    with patch("zeep.Client", autospec=True), patch(
+    with patch(
         "TotalConnectClient.TotalConnectClient.request", side_effect=responses
     ) as mock_request:
         client = TotalConnectClient.TotalConnectClient(

--- a/tests/test_client_init.py
+++ b/tests/test_client_init.py
@@ -34,7 +34,7 @@ class TestTotalConnectClient(unittest.TestCase):
             RESPONSE_DISARMED,
         ]
 
-        with patch("zeep.Client", autospec=True), patch(
+        with patch(
             "TotalConnectClient.TotalConnectClient.request", side_effect=responses
         ) as mock_request:
             client = TotalConnectClient.TotalConnectClient(
@@ -50,7 +50,7 @@ class TestTotalConnectClient(unittest.TestCase):
             RESPONSE_AUTHENTICATE_EMPTY,
         ]
 
-        with patch("zeep.Client", autospec=True), patch(
+        with patch(
             "TotalConnectClient.TotalConnectClient.request", side_effect=responses
         ) as mock_request, pytest.raises(Exception):
 
@@ -68,7 +68,7 @@ class TestTotalConnectClient(unittest.TestCase):
             RESPONSE_DISARMED,
         ]
 
-        with patch("zeep.Client", autospec=True), patch(
+        with patch(
             "TotalConnectClient.TotalConnectClient.request", side_effect=responses
         ) as mock_request:
             client = TotalConnectClient.TotalConnectClient(

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -58,9 +58,11 @@ class TestTotalConnectClient(unittest.TestCase):
             RESPONSE_DISARMED,
         ]
 
-        with patch("zeep.Client", autospec=True), patch(
+        with patch(
             "zeep.helpers.serialize_object", side_effect=serialize_responses
-        ), patch("builtins.eval", side_effect=eval_responses) as mock_request:
+        ), patch("TotalConnectClient.TotalConnectClient.setup_soap"), patch(
+            "builtins.eval", side_effect=eval_responses
+        ) as mock_request:
             client = TotalConnectClient.TotalConnectClient(
                 "username", "password", usercodes=None
             )
@@ -79,9 +81,11 @@ class TestTotalConnectClient(unittest.TestCase):
             RESPONSE_BAD_USER_OR_PASSWORD,
         ]
 
-        with patch("zeep.Client", autospec=True), patch(
+        with patch(
             "zeep.helpers.serialize_object", side_effect=serialize_responses
-        ), patch("builtins.eval", side_effect=eval_responses) as mock_request:
+        ), patch("TotalConnectClient.TotalConnectClient.setup_soap"), patch(
+            "builtins.eval", side_effect=eval_responses
+        ) as mock_request:
             client = TotalConnectClient.TotalConnectClient(
                 "username", "password", usercodes=None
             )
@@ -101,9 +105,11 @@ class TestTotalConnectClient(unittest.TestCase):
             )
             serialize_responses.append(RESPONSE_FAILED_TO_CONNECT)
 
-        with patch("zeep.Client", autospec=True), patch(
+        with patch(
             "zeep.helpers.serialize_object", side_effect=serialize_responses
-        ), patch("time.sleep", autospec=True), patch(
+        ), patch("TotalConnectClient.TotalConnectClient.setup_soap"), patch(
+            "time.sleep", autospec=True
+        ), patch(
             "builtins.eval", side_effect=eval_responses
         ) as mock_request, pytest.raises(
             Exception
@@ -134,9 +140,11 @@ class TestTotalConnectClient(unittest.TestCase):
             )
             serialize_responses.append(RESPONSE_CONNECTION_ERROR)
 
-        with patch("zeep.Client", autospec=True), patch(
+        with patch(
             "zeep.helpers.serialize_object", side_effect=serialize_responses
-        ), patch("time.sleep", autospec=True), patch(
+        ), patch("TotalConnectClient.TotalConnectClient.setup_soap"), patch(
+            "time.sleep", autospec=True
+        ), patch(
             "builtins.eval", side_effect=eval_responses
         ) as mock_request, pytest.raises(
             Exception
@@ -185,9 +193,11 @@ class TestTotalConnectClient(unittest.TestCase):
             RESPONSE_ARMED_AWAY,
         ]
 
-        with patch("zeep.Client", autospec=True), patch(
+        with patch(
             "zeep.helpers.serialize_object", side_effect=serialize_responses
-        ), patch("builtins.eval", side_effect=eval_responses) as mock_request:
+        ), patch("TotalConnectClient.TotalConnectClient.setup_soap"), patch(
+            "builtins.eval", side_effect=eval_responses
+        ) as mock_request:
             client = TotalConnectClient.TotalConnectClient(
                 "username", "password", usercodes=None
             )
@@ -208,9 +218,11 @@ class TestTotalConnectClient(unittest.TestCase):
             RESPONSE_UNKNOWN,
         ]
 
-        with patch("zeep.Client", autospec=True), patch(
+        with patch(
             "zeep.helpers.serialize_object", side_effect=serialize_responses
-        ), patch("builtins.eval", side_effect=eval_responses) as mock_request:
+        ), patch("TotalConnectClient.TotalConnectClient.setup_soap"), patch(
+            "builtins.eval", side_effect=eval_responses
+        ) as mock_request:
             client = TotalConnectClient.TotalConnectClient(
                 "username", "password", usercodes=None
             )

--- a/total_connect_client/TotalConnectClient.py
+++ b/total_connect_client/TotalConnectClient.py
@@ -70,8 +70,9 @@ class TotalConnectClient:
         """Initialize."""
         self.times = {}
         self.time_start = time.time()
-        self.soapClient = zeep.Client("https://rs.alarmnet.com/TC21api/tc2.asmx?WSDL")
+        self.soapClient = None
         self.soap_base = "self.soapClient.service."
+        self.soap_ready = False
 
         self.applicationId = "14588"
         self.applicationVersion = "1.0.34"
@@ -127,8 +128,16 @@ class TotalConnectClient:
 
         return msg
 
+    def setup_soap(self):
+        """Set up soap for use."""
+        self.soapClient = zeep.Client("https://rs.alarmnet.com/TC21api/tc2.asmx?WSDL")
+        self.soap_ready = True
+
     def request(self, request, attempts=0):
         """Send a SOAP request."""
+        if self.soap_ready is False:
+            self.setup_soap()
+
         if attempts < self.MAX_REQUEST_ATTEMPTS:
             attempts += 1
             response = eval(self.soap_base + request)


### PR DESCRIPTION
Move soap setup outside of __init__.  This will allow easier patching of the soap calls to avoid I/O during testing with Home Assistant.