### PR TITLE
factor arming state predicates into new enum ArmingState

### DIFF
--- a/tests/const.py
+++ b/tests/const.py
@@ -1,7 +1,7 @@
 """Testing constants."""
+
+from total_connect_client.const import ArmingState
 from total_connect_client.client import TotalConnectClient
-from total_connect_client.location import TotalConnectLocation
-from total_connect_client.partition import TotalConnectPartition
 from total_connect_client.zone import (
     ZONE_STATUS_LOW_BATTERY,
     ZONE_STATUS_NORMAL,
@@ -118,27 +118,27 @@ RESPONSE_GET_ZONE_DETAILS_NONE["ZoneStatus"] = None
 
 PARTITION_DISARMED = {
     "PartitionID": "1",
-    "ArmingState": TotalConnectLocation.DISARMED,
+    "ArmingState": ArmingState.DISARMED.value,
 }
 
 PARTITION_DISARMED2 = {
     "PartitionID": "2",
-    "ArmingState": TotalConnectLocation.DISARMED,
+    "ArmingState": ArmingState.DISARMED.value,
 }
 
 PARTITION_ARMED_STAY = {
     "PartitionID": "1",
-    "ArmingState": TotalConnectLocation.ARMED_STAY,
+    "ArmingState": ArmingState.ARMED_STAY.value,
 }
 
 PARTITION_ARMED_STAY_NIGHT = {
     "PartitionID": "1",
-    "ArmingState": TotalConnectLocation.ARMED_STAY_NIGHT,
+    "ArmingState": ArmingState.ARMED_STAY_NIGHT.value,
 }
 
 PARTITION_ARMED_AWAY = {
     "PartitionID": "1",
-    "ArmingState": TotalConnectLocation.ARMED_AWAY,
+    "ArmingState": ArmingState.ARMED_AWAY.value,
 }
 
 PARTITION_INFO_DISARMED = {}
@@ -194,24 +194,24 @@ RESPONSE_DISARMED = {
     "ResultCode": 0,
     "ResultData": "Success",
     "PanelMetadataAndStatus": METADATA_DISARMED,
-    "ArmingState": TotalConnectLocation.DISARMED,
+    "ArmingState": ArmingState.DISARMED.value,
 }
 RESPONSE_ARMED_STAY = {
     "ResultCode": 0,
     "ResultData": "Success",
     "PanelMetadataAndStatus": METADATA_ARMED_STAY,
-    "ArmingState": TotalConnectLocation.ARMED_STAY,
+    "ArmingState": ArmingState.ARMED_STAY.value,
 }
 RESPONSE_ARMED_STAY_NIGHT = {
     "ResultCode": 0,
     "PanelMetadataAndStatus": METADATA_ARMED_STAY_NIGHT,
-    "ArmingState": TotalConnectLocation.ARMED_STAY_NIGHT,
+    "ArmingState": ArmingState.ARMED_STAY_NIGHT.value,
 }
 RESPONSE_ARMED_AWAY = {
     "ResultCode": 0,
     "ResultData": "Success",
     "PanelMetadataAndStatus": METADATA_ARMED_AWAY,
-    "ArmingState": TotalConnectLocation.ARMED_AWAY,
+    "ArmingState": ArmingState.ARMED_AWAY.value,
 }
 
 RESPONSE_AUTHENTICATE = {
@@ -264,13 +264,13 @@ RESPONSE_UNKNOWN = {
 
 PARTITION_DETAILS_1 = {
     "PartitionID": 1,
-    "ArmingState": TotalConnectPartition.DISARMED,
+    "ArmingState": ArmingState.DISARMED.value,
     "PartitionName": "Test1",
 }
 
 PARTITION_DETAILS_2 = {
     "PartitionID": 2,
-    "ArmingState": TotalConnectPartition.DISARMED,
+    "ArmingState": ArmingState.DISARMED.value,
     "PartitionName": "Test2",
 }
 

--- a/tests/test_client_arm_disarm.py
+++ b/tests/test_client_arm_disarm.py
@@ -78,7 +78,7 @@ class TestTotalConnectClient(unittest.TestCase):
 
             # confirm armed_away
             self.client.get_panel_meta_data(self.location_id)
-            assert self.client.locations[self.location_id].is_armed_away() is True
+            assert self.client.locations[self.location_id].arming_state.is_armed_away() is True
 
         # second test with a zone faulted
         self.client = create_client()
@@ -89,8 +89,8 @@ class TestTotalConnectClient(unittest.TestCase):
 
             # should still be disarmed
             self.client.get_panel_meta_data(self.location_id)
-            assert self.client.locations[self.location_id].is_armed_away() is False
-            assert self.client.locations[self.location_id].is_disarmed() is True
+            assert self.client.locations[self.location_id].arming_state.is_armed_away() is False
+            assert self.client.locations[self.location_id].arming_state.is_disarmed() is True
 
         # third test with bad usercode
         self.client = create_client()
@@ -101,8 +101,8 @@ class TestTotalConnectClient(unittest.TestCase):
 
             # should still be disarmed
             self.client.get_panel_meta_data(self.location_id)
-            assert self.client.locations[self.location_id].is_armed_away() is False
-            assert self.client.locations[self.location_id].is_disarmed() is True
+            assert self.client.locations[self.location_id].arming_state.is_armed_away() is False
+            assert self.client.locations[self.location_id].arming_state.is_disarmed() is True
 
         # fourth test with 'unavailable' usercode
         self.client = create_client()
@@ -113,8 +113,8 @@ class TestTotalConnectClient(unittest.TestCase):
 
             # should still be disarmed
             self.client.get_panel_meta_data(self.location_id)
-            assert self.client.locations[self.location_id].is_armed_away() is False
-            assert self.client.locations[self.location_id].is_disarmed() is True
+            assert self.client.locations[self.location_id].arming_state.is_armed_away() is False
+            assert self.client.locations[self.location_id].arming_state.is_disarmed() is True
 
         # fifth test with 'other' usercode
         self.client = create_client()
@@ -125,8 +125,8 @@ class TestTotalConnectClient(unittest.TestCase):
 
             # should still be disarmed
             self.client.get_panel_meta_data(self.location_id)
-            assert self.client.locations[self.location_id].is_armed_away() is False
-            assert self.client.locations[self.location_id].is_disarmed() is True
+            assert self.client.locations[self.location_id].arming_state.is_armed_away() is False
+            assert self.client.locations[self.location_id].arming_state.is_disarmed() is True
 
     def tests_arm_away_instant(self):
         """Test arm away instant."""
@@ -138,7 +138,7 @@ class TestTotalConnectClient(unittest.TestCase):
 
             # confirm armed_away
             self.client.get_panel_meta_data(self.location_id)
-            assert self.client.locations[self.location_id].is_armed_away() is True
+            assert self.client.locations[self.location_id].arming_state.is_armed_away() is True
 
         # second test with a zone faulted
         self.client = create_client()
@@ -149,8 +149,8 @@ class TestTotalConnectClient(unittest.TestCase):
 
             # should still be disarmed
             self.client.get_panel_meta_data(self.location_id)
-            assert self.client.locations[self.location_id].is_armed_away() is False
-            assert self.client.locations[self.location_id].is_disarmed() is True
+            assert self.client.locations[self.location_id].arming_state.is_armed_away() is False
+            assert self.client.locations[self.location_id].arming_state.is_disarmed() is True
 
         # third test with bad usercode
         self.client = create_client()
@@ -161,8 +161,8 @@ class TestTotalConnectClient(unittest.TestCase):
 
             # should still be disarmed
             self.client.get_panel_meta_data(self.location_id)
-            assert self.client.locations[self.location_id].is_armed_away() is False
-            assert self.client.locations[self.location_id].is_disarmed() is True
+            assert self.client.locations[self.location_id].arming_state.is_armed_away() is False
+            assert self.client.locations[self.location_id].arming_state.is_disarmed() is True
 
     def tests_arm_stay(self):
         """Test arm stay."""
@@ -174,7 +174,7 @@ class TestTotalConnectClient(unittest.TestCase):
 
             # confirm armed_away
             self.client.get_panel_meta_data(self.location_id)
-            assert self.client.locations[self.location_id].is_armed_home() is True
+            assert self.client.locations[self.location_id].arming_state.is_armed_home() is True
 
         # second test with a zone faulted
         self.client = create_client()
@@ -185,8 +185,8 @@ class TestTotalConnectClient(unittest.TestCase):
 
             # should still be disarmed
             self.client.get_panel_meta_data(self.location_id)
-            assert self.client.locations[self.location_id].is_armed_home() is False
-            assert self.client.locations[self.location_id].is_disarmed() is True
+            assert self.client.locations[self.location_id].arming_state.is_armed_home() is False
+            assert self.client.locations[self.location_id].arming_state.is_disarmed() is True
 
         # third test with bad usercode
         self.client = create_client()
@@ -197,8 +197,8 @@ class TestTotalConnectClient(unittest.TestCase):
 
             # should still be disarmed
             self.client.get_panel_meta_data(self.location_id)
-            assert self.client.locations[self.location_id].is_armed_home() is False
-            assert self.client.locations[self.location_id].is_disarmed() is True
+            assert self.client.locations[self.location_id].arming_state.is_armed_home() is False
+            assert self.client.locations[self.location_id].arming_state.is_disarmed() is True
 
     def tests_arm_stay_instant(self):
         """Test arm stay instant."""
@@ -210,7 +210,7 @@ class TestTotalConnectClient(unittest.TestCase):
 
             # confirm armed_away
             self.client.get_panel_meta_data(self.location_id)
-            assert self.client.locations[self.location_id].is_armed_home() is True
+            assert self.client.locations[self.location_id].arming_state.is_armed_home() is True
 
         # second test with a zone faulted
         self.client = create_client()
@@ -221,8 +221,8 @@ class TestTotalConnectClient(unittest.TestCase):
 
             # should still be disarmed
             self.client.get_panel_meta_data(self.location_id)
-            assert self.client.locations[self.location_id].is_armed_home() is False
-            assert self.client.locations[self.location_id].is_disarmed() is True
+            assert self.client.locations[self.location_id].arming_state.is_armed_home() is False
+            assert self.client.locations[self.location_id].arming_state.is_disarmed() is True
 
         # third test with bad usercode
         self.client = create_client()
@@ -233,8 +233,8 @@ class TestTotalConnectClient(unittest.TestCase):
 
             # should still be disarmed
             self.client.get_panel_meta_data(self.location_id)
-            assert self.client.locations[self.location_id].is_armed_home() is False
-            assert self.client.locations[self.location_id].is_disarmed() is True
+            assert self.client.locations[self.location_id].arming_state.is_armed_home() is False
+            assert self.client.locations[self.location_id].arming_state.is_disarmed() is True
 
     def tests_arm_stay_night(self):
         """Test arm stay night."""
@@ -246,7 +246,7 @@ class TestTotalConnectClient(unittest.TestCase):
 
             # confirm armed_away
             self.client.get_panel_meta_data(self.location_id)
-            assert self.client.locations[self.location_id].is_armed_night() is True
+            assert self.client.locations[self.location_id].arming_state.is_armed_night() is True
 
         # second test with a zone faulted
         self.client = create_client()
@@ -257,8 +257,8 @@ class TestTotalConnectClient(unittest.TestCase):
 
             # should still be disarmed
             self.client.get_panel_meta_data(self.location_id)
-            assert self.client.locations[self.location_id].is_armed_night() is False
-            assert self.client.locations[self.location_id].is_disarmed() is True
+            assert self.client.locations[self.location_id].arming_state.is_armed_night() is False
+            assert self.client.locations[self.location_id].arming_state.is_disarmed() is True
 
         # third test with bad usercode
         self.client = create_client()
@@ -269,8 +269,8 @@ class TestTotalConnectClient(unittest.TestCase):
 
             # should still be disarmed
             self.client.get_panel_meta_data(self.location_id)
-            assert self.client.locations[self.location_id].is_armed_night() is False
-            assert self.client.locations[self.location_id].is_disarmed() is True
+            assert self.client.locations[self.location_id].arming_state.is_armed_night() is False
+            assert self.client.locations[self.location_id].arming_state.is_disarmed() is True
 
     def tests_disarm(self):
         """Test disarm."""
@@ -286,12 +286,12 @@ class TestTotalConnectClient(unittest.TestCase):
             # arm the system and confirm armed_away
             self.client.arm_away(self.location_id)
             self.client.get_panel_meta_data(self.location_id)
-            assert self.client.locations[self.location_id].is_armed_away() is True
+            assert self.client.locations[self.location_id].arming_state.is_armed_away() is True
 
             # now disarm
             self.client.disarm(self.location_id)
             self.client.get_panel_meta_data(self.location_id)
-            assert self.client.locations[self.location_id].is_disarmed() is True
+            assert self.client.locations[self.location_id].arming_state.is_disarmed() is True
 
     def tests_disarm_command_failed(self):
         """Test disarm with command failed."""
@@ -307,7 +307,7 @@ class TestTotalConnectClient(unittest.TestCase):
             # arm the system and confirm armed_away
             self.client.arm_away(self.location_id)
             self.client.get_panel_meta_data(self.location_id)
-            assert self.client.locations[self.location_id].is_armed_away() is True
+            assert self.client.locations[self.location_id].arming_state.is_armed_away() is True
 
             # now disarm, should fail
             with pytest.raises(BadResultCodeError):
@@ -315,7 +315,7 @@ class TestTotalConnectClient(unittest.TestCase):
 
             # should still be armed_away
             self.client.get_panel_meta_data(self.location_id)
-            assert self.client.locations[self.location_id].is_armed_away() is True
+            assert self.client.locations[self.location_id].arming_state.is_armed_away() is True
 
     def tests_disarm_user_code_invalid(self):
         """Test disarm with invalid user code."""
@@ -331,14 +331,14 @@ class TestTotalConnectClient(unittest.TestCase):
             # arm the system and confirm armed_away
             self.client.arm_away(self.location_id)
             self.client.get_panel_meta_data(self.location_id)
-            assert self.client.locations[self.location_id].is_armed_away() is True
+            assert self.client.locations[self.location_id].arming_state.is_armed_away() is True
 
             with pytest.raises(BadResultCodeError):
                 self.client.disarm(self.location_id)
 
             # should still be armed_away when disarming fails
             self.client.get_panel_meta_data(self.location_id)
-            assert self.client.locations[self.location_id].is_armed_away() is True
+            assert self.client.locations[self.location_id].arming_state.is_armed_away() is True
 
     def tests_disarm_disarmed(self):
         """Test attempt to disarm an already disarmed system."""
@@ -348,9 +348,9 @@ class TestTotalConnectClient(unittest.TestCase):
         responses = [RESPONSE_DISARMED, RESPONSE_SUCCESS, RESPONSE_DISARMED]
         with patch(TCC_REQUEST_METHOD, side_effect=responses):
             self.client.get_panel_meta_data(self.location_id)
-            assert self.client.locations[self.location_id].is_disarmed() is True
+            assert self.client.locations[self.location_id].arming_state.is_disarmed() is True
 
             # now disarm
             self.client.disarm(self.location_id)
             self.client.get_panel_meta_data(self.location_id)
-            assert self.client.locations[self.location_id].is_disarmed() is True
+            assert self.client.locations[self.location_id].arming_state.is_disarmed() is True

--- a/tests/test_client_get_panel_meta_data.py
+++ b/tests/test_client_get_panel_meta_data.py
@@ -33,34 +33,34 @@ class TestTotalConnectClient(unittest.TestCase):
         responses = [RESPONSE_ARMED_AWAY, RESPONSE_DISARMED]
         with patch("total_connect_client.client.TotalConnectClient.request", side_effect=responses):
             # should start disarmed
-            assert self.client.locations[self.location_id].is_disarmed() is True
+            assert self.client.locations[self.location_id].arming_state.is_disarmed() is True
 
             # first response shows armed_away
             self.client.get_panel_meta_data(self.location_id)
-            assert self.client.locations[self.location_id].is_armed_away() is True
+            assert self.client.locations[self.location_id].arming_state.is_armed_away() is True
 
             # second response shows disarmed
             self.client.get_panel_meta_data(self.location_id)
-            assert self.client.locations[self.location_id].is_disarmed() is True
+            assert self.client.locations[self.location_id].arming_state.is_disarmed() is True
 
     def tests_get_panel_meta_data_none(self):
         """Test get_panel_meta_data() with an empty PanelMetadataAndStatus response."""
         responses = [RESPONSE_DISARMED_NONE]
         with patch("total_connect_client.client.TotalConnectClient.request", side_effect=responses):
             # should start disarmed
-            assert self.client.locations[self.location_id].is_disarmed() is True
+            assert self.client.locations[self.location_id].arming_state.is_disarmed() is True
 
             # first response gives empty status...should remain the same
             with pytest.raises(PartialResponseError):
                 self.client.get_panel_meta_data(self.location_id)
-            assert self.client.locations[self.location_id].is_disarmed() is True
+            assert self.client.locations[self.location_id].arming_state.is_disarmed() is True
 
     def tests_get_panel_meta_data_failed(self):
         """Test get_panel_meta_data() with an empty PanelMetadataAndStatus response."""
         responses = [RESPONSE_FEATURE_NOT_SUPPORTED]
         with patch("total_connect_client.client.TotalConnectClient.request", side_effect=responses):
             # should start disarmed
-            assert self.client.locations[self.location_id].is_disarmed() is True
+            assert self.client.locations[self.location_id].arming_state.is_disarmed() is True
 
             with pytest.raises(BadResultCodeError):
                 self.client.get_panel_meta_data(self.location_id)

--- a/tests/test_client_misc.py
+++ b/tests/test_client_misc.py
@@ -39,7 +39,7 @@ class TestTotalConnectClient(unittest.TestCase):
         responses = [RESPONSE_DISARMED]
         with patch("total_connect_client.client.TotalConnectClient.request", side_effect=responses):
             # should start disarmed
-            assert self.client.locations[self.location_id].is_disarmed() is True
+            assert self.client.locations[self.location_id].arming_state.is_disarmed() is True
 
             # ask for status of zone 1, which exists
             assert self.client.zone_status(self.location_id, "1") is ZONE_STATUS_NORMAL

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -54,19 +54,19 @@ class TestTotalConnectLocation(unittest.TestCase):
 
     def tests_status(self):
         """Normal zone."""
-        self.assertFalse(self.location_normal.is_arming())
-        self.assertFalse(self.location_normal.is_disarming())
-        self.assertTrue(self.location_normal.is_disarmed())
-        self.assertFalse(self.location_normal.is_armed_away())
-        self.assertFalse(self.location_normal.is_armed_custom_bypass())
-        self.assertFalse(self.location_normal.is_armed_home())
-        self.assertFalse(self.location_normal.is_armed_night())
-        self.assertFalse(self.location_normal.is_armed())
-        self.assertFalse(self.location_normal.is_pending())
-        self.assertFalse(self.location_normal.is_triggered_police())
-        self.assertFalse(self.location_normal.is_triggered_fire())
-        self.assertFalse(self.location_normal.is_triggered_gas())
-        self.assertFalse(self.location_normal.is_triggered())
+        self.assertFalse(self.location_normal.arming_state.is_arming())
+        self.assertFalse(self.location_normal.arming_state.is_disarming())
+        self.assertTrue(self.location_normal.arming_state.is_disarmed())
+        self.assertFalse(self.location_normal.arming_state.is_armed_away())
+        self.assertFalse(self.location_normal.arming_state.is_armed_custom_bypass())
+        self.assertFalse(self.location_normal.arming_state.is_armed_home())
+        self.assertFalse(self.location_normal.arming_state.is_armed_night())
+        self.assertFalse(self.location_normal.arming_state.is_armed())
+        self.assertFalse(self.location_normal.arming_state.is_pending())
+        self.assertFalse(self.location_normal.arming_state.is_triggered_police())
+        self.assertFalse(self.location_normal.arming_state.is_triggered_fire())
+        self.assertFalse(self.location_normal.arming_state.is_triggered_gas())
+        self.assertFalse(self.location_normal.arming_state.is_triggered())
 
         loc = TotalConnectLocation(LOCATION_INFO_BASIC_NORMAL, self)
         r = deepcopy(RESPONSE_DISARMED)
@@ -81,7 +81,7 @@ class TestTotalConnectLocation(unittest.TestCase):
         loc.update_partitions(deepcopy(RESPONSE_DISARMED))
         loc.update_zones(deepcopy(RESPONSE_DISARMED))
 
-        self.assertTrue(loc.is_disarmed())
+        self.assertTrue(loc.arming_state.is_disarmed())
         with pytest.raises(PartialResponseError):
             loc.set_status(None)
 
@@ -107,7 +107,7 @@ class TestTotalConnectLocation(unittest.TestCase):
         del data["PanelMetadataAndStatus"]["Zones"]
         with pytest.raises(TotalConnectError):
             loc.update_zones(data)
-        self.assertTrue(loc.is_disarmed())
+        self.assertTrue(loc.arming_state.is_disarmed())
 
     def tests_set_zone_details(self):
         """Test set_zone_details with normal data passed in."""

--- a/tests/test_location_arm_disarm.py
+++ b/tests/test_location_arm_disarm.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import unittest
 import pytest
 
-from total_connect_client.client import TotalConnectClient
+from total_connect_client.client import TotalConnectClient, ArmingHelper
 from total_connect_client.exceptions import BadResultCodeError, AuthenticationError
 
 from common import create_client
@@ -64,10 +64,10 @@ def tests_arm_away():
 
     responses = [RESPONSE_ARM_SUCCESS, RESPONSE_ARMED_AWAY]
     with patch(TCC_REQUEST_METHOD, side_effect=responses):
-        location.arm_away()
+        ArmingHelper(location).arm_away()
 
         # confirm armed_away
         location.get_panel_meta_data()
-        assert location.is_armed_away() is True
-        assert location.partitions[1].is_armed_away() is True
+        assert location.arming_state.is_armed_away()
+        assert location.partitions[1].arming_state.is_armed_away()
 

--- a/tests/test_partition.py
+++ b/tests/test_partition.py
@@ -4,6 +4,8 @@ from copy import deepcopy
 from unittest.mock import Mock
 
 from const import PARTITION_DETAILS_1, PARTITION_DISARMED
+
+from total_connect_client.client import ArmingHelper
 from total_connect_client.partition import TotalConnectPartition
 from total_connect_client.exceptions import PartialResponseError
 
@@ -16,7 +18,7 @@ def tests_partition():
     assert test_partition.id == 1
 
     test_partition.update(PARTITION_DISARMED)
-    assert test_partition.arming_state == PARTITION_DISARMED["ArmingState"]
+    assert test_partition.arming_state.value == PARTITION_DISARMED["ArmingState"]
 
     # remove ArmingState
     data = deepcopy(PARTITION_DETAILS_1)
@@ -36,7 +38,7 @@ def tests_str():
     data = (
         f"PARTITION {PARTITION_DETAILS_1['PartitionID']} - "
         f"{PARTITION_DETAILS_1['PartitionName']}\n"
-        f"  ArmingState: {PARTITION_DETAILS_1['ArmingState']}\n"
+        f"  ArmingState.DISARMED\n"
     )
 
     assert str(test_partition) == data
@@ -48,22 +50,22 @@ def tests_arm_disarm():
     partition = TotalConnectPartition(PARTITION_DETAILS_1, location)
 
     location.arm_away.return_value = None
-    partition.arm_away()
+    ArmingHelper(partition).arm_away()
 
     location.arm_stay.return_value = None
-    partition.arm_stay()
+    ArmingHelper(partition).arm_stay()
 
     location.arm_stay_instant.return_value = None
-    partition.arm_stay_instant()
+    ArmingHelper(partition).arm_stay_instant()
 
     location.arm_away_instant.return_value = None
-    partition.arm_away_instant()
+    ArmingHelper(partition).arm_away_instant()
 
     location.arm_stay_night.return_value = None
-    partition.arm_stay_night()
+    ArmingHelper(partition).arm_stay_night()
 
     location.disarm.return_value = None
-    partition.disarm()
+    ArmingHelper(partition).disarm()
 
 
 def tests_arming_state():
@@ -71,16 +73,16 @@ def tests_arming_state():
 
     partition = TotalConnectPartition(PARTITION_DETAILS_1, None)
 
-    assert partition.is_disarming() is False
-    assert partition.is_disarmed() is True
-    assert partition.is_arming() is False
-    assert partition.is_armed() is False
-    assert partition.is_armed_away() is False
-    assert partition.is_armed_custom_bypass() is False
-    assert partition.is_armed_home() is False
-    assert partition.is_armed_night() is False
-    assert partition.is_pending() is False
-    assert partition.is_triggered_police() is False
-    assert partition.is_triggered_fire() is False
-    assert partition.is_triggered_gas() is False
-    assert partition.is_triggered() is False
+    assert partition.arming_state.is_disarming() is False
+    assert partition.arming_state.is_disarmed() is True
+    assert partition.arming_state.is_arming() is False
+    assert partition.arming_state.is_armed() is False
+    assert partition.arming_state.is_armed_away() is False
+    assert partition.arming_state.is_armed_custom_bypass() is False
+    assert partition.arming_state.is_armed_home() is False
+    assert partition.arming_state.is_armed_night() is False
+    assert partition.arming_state.is_pending() is False
+    assert partition.arming_state.is_triggered_police() is False
+    assert partition.arming_state.is_triggered_fire() is False
+    assert partition.arming_state.is_triggered_gas() is False
+    assert partition.arming_state.is_triggered() is False

--- a/total_connect_client/__init__.py
+++ b/total_connect_client/__init__.py
@@ -8,12 +8,6 @@ and TotalConnectZone (from .location, .partition, and .zone respectively), but
 users of this interface never create those themselves.
 """
 
-from .client import TotalConnectClient
+from .const import ArmType, ArmingState
 
-from .const import (
-    ARM_TYPE_AWAY,
-    ARM_TYPE_STAY,
-    ARM_TYPE_STAY_INSTANT,
-    ARM_TYPE_AWAY_INSTANT,
-    ARM_TYPE_STAY_NIGHT,
-)
+from .client import TotalConnectClient, ArmingHelper

--- a/total_connect_client/client.py
+++ b/total_connect_client/client.py
@@ -14,6 +14,7 @@ import warnings
 
 import zeep
 
+from .const import ArmType
 from .location import TotalConnectLocation
 from .user import TotalConnectUser
 from .exceptions import (
@@ -22,16 +23,6 @@ from .exceptions import (
 )
 
 PROJECT_URL = "https://github.com/craigjmidwinter/total-connect-client"
-
-ARM_TYPE_AWAY = 0
-ARM_TYPE_STAY = 1
-ARM_TYPE_STAY_INSTANT = 2
-ARM_TYPE_AWAY_INSTANT = 3
-ARM_TYPE_STAY_NIGHT = 4
-
-RESULT_SUCCESS = 0
-
-GET_ALL_SENSORS_MASK_STATUS_SUCCESS = 0
 
 DEFAULT_USERCODE = "-1"
 
@@ -307,7 +298,7 @@ class TotalConnectClient:
             "Using deprecated client.arm_away(). " "Use location.arm_away().",
             DeprecationWarning,
         )
-        return self.arm(ARM_TYPE_AWAY, location_id)
+        return self.arm(ArmType.AWAY, location_id)
 
     def arm_stay(self, location_id):
         """Arm the system (Stay)."""
@@ -315,7 +306,7 @@ class TotalConnectClient:
             "Using deprecated client.arm_stay(). " "Use location.arm_stay().",
             DeprecationWarning,
         )
-        return self.arm(ARM_TYPE_STAY, location_id)
+        return self.arm(ArmType.STAY, location_id)
 
     def arm_stay_instant(self, location_id):
         """Arm the system (Stay - Instant)."""
@@ -324,7 +315,7 @@ class TotalConnectClient:
             "Use location.arm_stay_instant().",
             DeprecationWarning,
         )
-        return self.arm(ARM_TYPE_STAY_INSTANT, location_id)
+        return self.arm(ArmType.STAY_INSTANT, location_id)
 
     def arm_away_instant(self, location_id):
         """Arm the system (Away - Instant)."""
@@ -333,7 +324,7 @@ class TotalConnectClient:
             "Use location.arm_away_instant().",
             DeprecationWarning,
         )
-        return self.arm(ARM_TYPE_AWAY_INSTANT, location_id)
+        return self.arm(ArmType.AWAY_INSTANT, location_id)
 
     def arm_stay_night(self, location_id):
         """Arm the system (Stay - Night)."""
@@ -342,7 +333,7 @@ class TotalConnectClient:
             "Use location.arm_stay_night().",
             DeprecationWarning,
         )
-        return self.arm(ARM_TYPE_STAY_NIGHT, location_id)
+        return self.arm(ArmType.STAY_NIGHT, location_id)
 
     def arm(self, arm_type, location_id):
         """Arm the system. Return True if successful."""
@@ -401,3 +392,38 @@ class TotalConnectClient:
             DeprecationWarning,
         )
         return self.locations[location_id].get_zone_details()
+
+
+class ArmingHelper:
+    """
+    For a partition or location, you can call its arm() or disarm() method directly.
+       Example: partition.arm(ArmType.AWAY)
+
+    Alternatively, you can use ArmingHelper.
+       Example: ArmingHelper(partition).arm_away()
+    """
+    def __init__(self, partition_or_location):
+        self.armable = partition_or_location
+
+    def arm_away(self):
+        """Arm the system (Away)."""
+        self.armable.arm(ArmType.AWAY)
+
+    def arm_stay(self):
+        """Arm the system (Stay)."""
+        self.armable.arm(ArmType.STAY)
+
+    def arm_stay_instant(self):
+        """Arm the system (Stay - Instant)."""
+        self.armable.arm(ArmType.STAY_INSTANT)
+
+    def arm_away_instant(self):
+        """Arm the system (Away - Instant)."""
+        self.armable.arm(ArmType.AWAY_INSTANT)
+
+    def arm_stay_night(self):
+        """Arm the system (Stay - Night)."""
+        self.armable.arm(ArmType.STAY_NIGHT)
+
+    def disarm(self):
+        self.armable.disarm()

--- a/total_connect_client/const.py
+++ b/total_connect_client/const.py
@@ -1,9 +1,106 @@
 """Total Connect Client constants."""
 
-ARM_TYPE_AWAY = 0
-ARM_TYPE_STAY = 1
-ARM_TYPE_STAY_INSTANT = 2
-ARM_TYPE_AWAY_INSTANT = 3
-ARM_TYPE_STAY_NIGHT = 4
+from enum import Enum
 
-RESULT_SUCCESS = 0
+
+class ArmType(Enum):
+    AWAY         = 0
+    STAY         = 1
+    STAY_INSTANT = 2
+    AWAY_INSTANT = 3
+    STAY_NIGHT   = 4
+
+
+class ArmingState(Enum):
+    DISARMED                  = 10200
+    DISARMED_BYPASS           = 10211
+
+    ARMED_AWAY                = 10201
+    ARMED_AWAY_BYPASS         = 10202
+    ARMED_STAY                = 10203
+    ARMED_STAY_BYPASS         = 10204
+    ARMED_AWAY_INSTANT        = 10205
+    ARMED_AWAY_INSTANT_BYPASS = 10206
+    ARMED_STAY_INSTANT        = 10209
+    ARMED_STAY_INSTANT_BYPASS = 10210
+    ARMED_STAY_NIGHT          = 10218
+    ARMED_CUSTOM_BYPASS       = 10223
+
+    ALARMING                  = 10207
+    ALARMING_FIRE_SMOKE       = 10212
+    ALARMING_CARBON_MONOXIDE  = 10213
+
+    ARMING                    = 10307
+    DISARMING                 = 10308
+
+    def is_arming(self):
+        """Return true if the system is in the process of arming."""
+        return self == ArmingState.ARMING
+
+    def is_disarming(self):
+        """Return true if the system is in the process of disarming."""
+        return self == ArmingState.DISARMING
+
+    def is_pending(self):
+        """Return true if the system is pending an action."""
+        return self.is_disarming() or self.is_arming()
+
+    def is_disarmed(self):
+        """Return True if the system is disarmed."""
+        return self in (ArmingState.DISARMED, ArmingState.DISARMED_BYPASS)
+
+    def is_armed_away(self):
+        """Return True if the system is armed away in any way."""
+        return self in (
+            ArmingState.ARMED_AWAY,
+            ArmingState.ARMED_AWAY_BYPASS,
+            ArmingState.ARMED_AWAY_INSTANT,
+            ArmingState.ARMED_AWAY_INSTANT_BYPASS,
+        )
+
+    def is_armed_custom_bypass(self):
+        """Return True if the system is armed custom bypass in any way."""
+        return self == ArmingState.ARMED_CUSTOM_BYPASS
+
+    def is_armed_home(self):
+        """Return True if the system is armed home/stay in any way."""
+        return self in (
+            ArmingState.ARMED_STAY,
+            ArmingState.ARMED_STAY_BYPASS,
+            ArmingState.ARMED_STAY_INSTANT,
+            ArmingState.ARMED_STAY_INSTANT_BYPASS,
+            ArmingState.ARMED_STAY_NIGHT,
+        )
+
+    def is_armed_night(self):
+        """Return True if the system is armed night in any way."""
+        return self == ArmingState.ARMED_STAY_NIGHT
+
+    def is_armed(self):
+        """Return True if the system is armed in any way."""
+        return (
+            self.is_armed_away()
+            or self.is_armed_custom_bypass()
+            or self.is_armed_home()
+            or self.is_armed_night()
+        )
+
+    def is_triggered_police(self):
+        """Return True if the system is triggered for police or medical."""
+        return self == ArmingState.ALARMING
+
+    def is_triggered_fire(self):
+        """Return True if the system is triggered for fire or smoke."""
+        return self == ArmingState.ALARMING_FIRE_SMOKE
+
+    def is_triggered_gas(self):
+        """Return True if the system is triggered for carbon monoxide."""
+        return self == ArmingState.ALARMING_CARBON_MONOXIDE
+
+    def is_triggered(self):
+        """Return True if the system is triggered in any way."""
+        return (
+            self.is_triggered_fire()
+            or self.is_triggered_gas()
+            or self.is_triggered_police()
+        )

--- a/total_connect_client/partition.py
+++ b/total_connect_client/partition.py
@@ -1,44 +1,25 @@
 """Total Connect Partition."""
 
 from .exceptions import PartialResponseError
+from .const import ArmingState
+
 
 class TotalConnectPartition:
     """Partition class for Total Connect."""
 
-
-    # ArmingState
-    DISARMED = 10200
-    DISARMED_BYPASS = 10211
-    ARMED_AWAY = 10201
-    ARMED_AWAY_BYPASS = 10202
-    ARMED_AWAY_INSTANT = 10205
-    ARMED_AWAY_INSTANT_BYPASS = 10206
-    ARMED_CUSTOM_BYPASS = 10223
-    ARMED_STAY = 10203
-    ARMED_STAY_BYPASS = 10204
-    ARMED_STAY_INSTANT = 10209
-    ARMED_STAY_INSTANT_BYPASS = 10210
-    ARMED_STAY_NIGHT = 10218
-    ARMING = 10307
-    DISARMING = 10308
-    ALARMING = 10207
-    ALARMING_FIRE_SMOKE = 10212
-    ALARMING_CARBON_MONOXIDE = 10213
-
     def __init__(self, details, parent):
         """Initialize Partition based on PartitionDetails."""
-        self.id = details.get("PartitionID")
-        self.arming_state = details.get("ArmingState")
-        self.name = details.get("PartitionName")
         self.parent = parent
+        self.id = details.get("PartitionID")
+        self.name = details.get("PartitionName")
+        self.update(details)
 
     def __str__(self):
         """Return a string that is printable."""
         data = (
             f"PARTITION {self.id} - {self.name}\n"
-            f"  ArmingState: {self.arming_state}\n"
+            f"  {self.arming_state}\n"
         )
-
         return data
 
     def update(self, info):
@@ -46,100 +27,12 @@ class TotalConnectPartition:
         astate = (info or {}).get("ArmingState")
         if astate is None:
             raise PartialResponseError('no ArmingState')
-        self.arming_state = astate
+        self.arming_state = ArmingState(astate)
 
-    def arm_away(self):
-        """Arm the partition (Away)."""
-        self.parent.arm_away(self.id)
-
-    def arm_stay(self):
-        """Arm the partition (Stay)."""
-        self.parent.arm_stay(self.id)
-
-    def arm_stay_instant(self):
-        """Arm the partition (Stay - Instant). True on success."""
-        self.parent.arm_stay_instant(self.id)
-
-    def arm_away_instant(self):
-        """Arm the partition (Away - Instant)."""
-        self.parent.arm_away_instant(self.id)
-
-    def arm_stay_night(self):
-        """Arm the partition (Stay - Night)."""
-        self.parent.arm_stay_night(self.id)
+    def arm(self, arm_type):
+        """Arm the partition."""
+        self.parent.arm(arm_type, self.id)
 
     def disarm(self):
         """Disarm the partition."""
         self.parent.disarm(self.id)
-
-    def is_arming(self):
-        """Return true if the system is in the process of arming."""
-        return self.arming_state == self.ARMING
-
-    def is_disarming(self):
-        """Return true if the system is in the process of disarming."""
-        return self.arming_state == self.DISARMING
-
-    def is_pending(self):
-        """Return true if the system is pending an action."""
-        return self.is_disarming() or self.is_arming()
-
-    def is_disarmed(self):
-        """Return True if the system is disarmed."""
-        return self.arming_state in (self.DISARMED, self.DISARMED_BYPASS)
-
-    def is_armed_away(self):
-        """Return True if the system is armed away in any way."""
-        return self.arming_state in (
-            self.ARMED_AWAY,
-            self.ARMED_AWAY_BYPASS,
-            self.ARMED_AWAY_INSTANT,
-            self.ARMED_AWAY_INSTANT_BYPASS,
-        )
-
-    def is_armed_custom_bypass(self):
-        """Return True if the system is armed custom bypass in any way."""
-        return self.arming_state == self.ARMED_CUSTOM_BYPASS
-
-    def is_armed_home(self):
-        """Return True if the system is armed home/stay in any way."""
-        return self.arming_state in (
-            self.ARMED_STAY,
-            self.ARMED_STAY_BYPASS,
-            self.ARMED_STAY_INSTANT,
-            self.ARMED_STAY_INSTANT_BYPASS,
-            self.ARMED_STAY_NIGHT,
-        )
-
-    def is_armed_night(self):
-        """Return True if the system is armed night in any way."""
-        return self.arming_state == self.ARMED_STAY_NIGHT
-
-    def is_armed(self):
-        """Return True if the system is armed in any way."""
-        return (
-            self.is_armed_away()
-            or self.is_armed_custom_bypass()
-            or self.is_armed_home()
-            or self.is_armed_night()
-        )
-
-    def is_triggered_police(self):
-        """Return True if the system is triggered for police or medical."""
-        return self.arming_state == self.ALARMING
-
-    def is_triggered_fire(self):
-        """Return True if the system is triggered for fire or smoke."""
-        return self.arming_state == self.ALARMING_FIRE_SMOKE
-
-    def is_triggered_gas(self):
-        """Return True if the system is triggered for carbon monoxide."""
-        return self.arming_state == self.ALARMING_CARBON_MONOXIDE
-
-    def is_triggered(self):
-        """Return True if the system is triggered in any way."""
-        return (
-            self.is_triggered_fire()
-            or self.is_triggered_gas()
-            or self.is_triggered_police()
-        )


### PR DESCRIPTION
convert loose constants to enums ArmType and ArmingState. ArmingState incorporates predicates is_arming() etc. Specific arm methods have been moved to client.ArmingHelper.

tox passes.

This is a competitor to Armable. I like this better. This clarifies what an ArmingState is, and it organizes the large number of predicates to make it clear they are predicates on ArmingState. There's no abstract base class, just returning an enum.

This includes ArmingHelper as we discussed. Now that ArmType is an enum, I'm not sure there's a big difference between
```
   ArmingHelper(partition_or_location).arm_stay_night()
```
and
```
   partition_or_location.arm(ArmType.STAY_NIGHT)
```
but I'm happy to have ArmingHelper if it means not duplicating those methods.

I have a different PR for the ZoneType enum which I'll send this evening.