### PR TITLE
log unknown server responses

### DIFF
--- a/total_connect_client/location.py
+++ b/total_connect_client/location.py
@@ -127,7 +127,11 @@ class TotalConnectLocation:
         astate = result.get("ArmingState")
         if not astate:
             raise PartialResponseError("no ArmingState", result)
-        self.arming_state = ArmingState(astate)
+        try:
+            self.arming_state = ArmingState(astate)
+        except ValueError:
+            LOGGER.error(f"unknown ArmingState {astate} in {result} -- please file an issue at https://github.com/craigjmidwinter/total-connect-client/issues")
+            raise
 
     def get_zone_details(self):
         """Get Zone details."""

--- a/total_connect_client/partition.py
+++ b/total_connect_client/partition.py
@@ -1,7 +1,12 @@
 """Total Connect Partition."""
 
+import logging
+
 from .const import ArmingState
 from .exceptions import PartialResponseError
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 class TotalConnectPartition:
@@ -24,7 +29,11 @@ class TotalConnectPartition:
         astate = (info or {}).get("ArmingState")
         if astate is None:
             raise PartialResponseError("no ArmingState")
-        self.arming_state = ArmingState(astate)
+        try:
+            self.arming_state = ArmingState(astate)
+        except ValueError:
+            LOGGER.error(f"unknown ArmingState {astate} in {result} -- please file an issue at https://github.com/craigjmidwinter/total-connect-client/issues")
+            raise
 
     def arm(self, arm_type):
         """Arm the partition."""


### PR DESCRIPTION
if we get an unknown ArmingState or ZoneStatus from the server, we log a message and raise the exception because we don't know how to proceed.

If we get an unknown ZoneType from the server, we log a message and continue because that won't affect our ability to function.

This also fixes a bug whereby ZoneType was not set to the num but was stored as the integer.