### PR TITLE
Make ResultCode public

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="total_connect_client",
-    version="2021.11.1",
+    version="2021.11.2",
     description="Interact with Total Connect 2 alarm systems",
     author="Craig J. Midwinter",
     author_email="craig.j.midwinter@gmail.com",

--- a/total_connect_client/__init__.py
+++ b/total_connect_client/__init__.py
@@ -17,6 +17,7 @@ ZoneStatus = zone.ZoneStatus
 ZoneType = zone.ZoneType
 ArmingState = const.ArmingState
 ArmType = const.ArmType
+ResultCode = const._ResultCode
 
 __all__ = [
     'TotalConnectClient', 'ArmType', 'ArmingState', 'ArmingHelper',


### PR DESCRIPTION
Makes the ResultCode enum public for use in Home Assistant testing.

Bump version to 2021.11.2