### PR TITLE
Retry on AUTHENTICATION_FAILED 

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,9 +1,12 @@
 # Version Information
 
+Keeping track of which version of Home Assistant includes which version of Total Connect Client to help with debugging user issues.
 
 Total Connect Client | Home Assistant | Notes
 ------------ | - | - 
-2021.8.3 | 2021.11.0
+2022.1 | 2022.2.0 |
+2021.11.4 | 2021.12.0 |
+2021.8.3 | 2021.11.0 |
 0.57 | 2021.3 |
 0.55 | 0.111.0 |
 0.54.1 | 0.108.2 |

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="total_connect_client",
-    version="2022.2",
+    version="2022.2.1",
     description="Interact with Total Connect 2 alarm systems",
     author="Craig J. Midwinter",
     author_email="craig.j.midwinter@gmail.com",

--- a/total_connect_client/client.py
+++ b/total_connect_client/client.py
@@ -134,6 +134,8 @@ class TotalConnectClient:
             raise RetryableTotalConnectError("connection error", response)
         if rc == _ResultCode.FAILED_TO_CONNECT:
             raise RetryableTotalConnectError("failed to connect with panel", response)
+        if rc == _ResultCode.AUTHENTICATION_FAILED:
+            raise RetryableTotalConnectError("temporary authentication failure", response)
 
     def raise_for_resultcode(self, response):
         """If response.ResultCode indicates success, return and do nothing.
@@ -150,7 +152,6 @@ class TotalConnectClient:
         self._raise_for_retry(response)
         if rc in (
                 _ResultCode.BAD_USER_OR_PASSWORD,
-                _ResultCode.AUTHENTICATION_FAILED,
                 _ResultCode.USER_CODE_UNAVAILABLE,
         ):
             raise AuthenticationError(rc.name, response)


### PR DESCRIPTION
The ResultCode -100 or AUTHENTICATION_FAILED seems to be an intermittent error, and not an indication of a bad username/password.  This PR retries the server request instead of triggering an AuthenticationError.

- Fixes #180 
- Bumps version to 2022.2.1
- Minor documentation update