### PR TITLE
Update invalid usercode handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Create an Issue on Github and post both your problem and your system information
 
 Why do we ask for this information?  The TotalConnect API documentation provides little information on the status codes and other information it returns about your system.  We developed as best we could using the codes our own systems returned.  We have seen many times that other users with issues have different system status codes.
 
+Also consider looking at the [Total Connect system status](https://status.resideo.com/) to see if there is a system wide problem. 
+
 ## Developer Interface
 
 If you're an end user, just install Home Assistant and things should just work.

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="total_connect_client",
-    version="2022.2.1",
+    version="2022.3",
     description="Interact with Total Connect 2 alarm systems",
     author="Craig J. Midwinter",
     author_email="craig.j.midwinter@gmail.com",

--- a/tests/test_client_arm_disarm.py
+++ b/tests/test_client_arm_disarm.py
@@ -15,7 +15,7 @@ from const import (
 
 from total_connect_client import ArmingHelper
 from total_connect_client.const import ArmingState, _ResultCode
-from total_connect_client.exceptions import AuthenticationError, BadResultCodeError
+from total_connect_client.exceptions import AuthenticationError, BadResultCodeError, UsercodeInvalid
 
 TCC_REQUEST_METHOD = "total_connect_client.client.TotalConnectClient.request"
 
@@ -86,7 +86,6 @@ class TestTotalConnectClient(unittest.TestCase):
             )
             for failresponse in (
                 RESPONSE_ARM_FAILED,  # "zone faulted"
-                RESPONSE_USER_CODE_INVALID,  # "bad usercode"
             ):
                 run(
                     BadResultCodeError,
@@ -195,7 +194,7 @@ class TestTotalConnectClient(unittest.TestCase):
             location.get_panel_meta_data()
             assert location.arming_state.is_armed_away()
 
-            with pytest.raises(BadResultCodeError):
+            with pytest.raises(UsercodeInvalid):
                 ArmingHelper(location).disarm()
 
             # should still be armed_away when disarming fails

--- a/tests/test_client_arm_disarm.py
+++ b/tests/test_client_arm_disarm.py
@@ -15,7 +15,7 @@ from const import (
 
 from total_connect_client import ArmingHelper
 from total_connect_client.const import ArmingState, _ResultCode
-from total_connect_client.exceptions import AuthenticationError, BadResultCodeError, UsercodeInvalid
+from total_connect_client.exceptions import AuthenticationError, BadResultCodeError, UsercodeInvalid, UsercodeUnavailable
 
 TCC_REQUEST_METHOD = "total_connect_client.client.TotalConnectClient.request"
 
@@ -95,7 +95,7 @@ class TestTotalConnectClient(unittest.TestCase):
                 )
             # last test has 'unavailable' usercode
             run(
-                AuthenticationError,
+                UsercodeUnavailable,
                 [RESPONSE_USER_CODE_UNAVAILABLE, RESPONSE_DISARMED],
                 armit,
                 ArmingState.DISARMED,

--- a/total_connect_client/client.py
+++ b/total_connect_client/client.py
@@ -27,6 +27,7 @@ from .exceptions import (
     ServiceUnavailable,
     TotalConnectError,
     UsercodeInvalid,
+    UsercodeUnavailable,
 )
 from .location import TotalConnectLocation
 from .user import TotalConnectUser
@@ -153,11 +154,10 @@ class TotalConnectClient:
         ):
             return
         self._raise_for_retry(response)
-        if rc in (
-                _ResultCode.BAD_USER_OR_PASSWORD,
-                _ResultCode.USER_CODE_UNAVAILABLE,
-        ):
+        if rc == _ResultCode.BAD_USER_OR_PASSWORD:
             raise AuthenticationError(rc.name, response)
+        if rc == _ResultCode.USER_CODE_UNAVAILABLE:
+            raise UsercodeUnavailable(rc.name, response)
         if rc == _ResultCode.USER_CODE_INVALID:
             raise UsercodeInvalid(rc.name, response)
         if rc == _ResultCode.FEATURE_NOT_SUPPORTED:
@@ -265,7 +265,7 @@ class TotalConnectClient:
         except UsercodeInvalid:
             LOGGER.warning(f"usercode {usercode} invalid for device {device_id}")
             return False
-        except AuthenticationError:
+        except UsercodeUnavailable:
             LOGGER.warning(f"usercode {usercode} unavailable for device {device_id}")
             return False
         return True

--- a/total_connect_client/exceptions.py
+++ b/total_connect_client/exceptions.py
@@ -34,3 +34,7 @@ class PartialResponseError(RetryableTotalConnectError):
     """Raised if the response is missing a section that it is always supposed to have.
     Because the TotalConnect servers are flaky, these are rather frequent.
     """
+
+
+class UsercodeInvalid(TotalConnectError):
+    """The provided usercode is invalid."""

--- a/total_connect_client/exceptions.py
+++ b/total_connect_client/exceptions.py
@@ -40,6 +40,12 @@ class UsercodeInvalid(TotalConnectError):
     """The provided usercode is invalid."""
 
 
+class UsercodeUnavailable(TotalConnectError):
+    """The TotalConnect usercode unavailable or invalid."""
+
+
+
 class ServiceUnavailable(TotalConnectError):
     """The TotalConnect service is unavailable or unreachable."""
+
 

--- a/total_connect_client/exceptions.py
+++ b/total_connect_client/exceptions.py
@@ -38,3 +38,8 @@ class PartialResponseError(RetryableTotalConnectError):
 
 class UsercodeInvalid(TotalConnectError):
     """The provided usercode is invalid."""
+
+
+class ServiceUnavailable(TotalConnectError):
+    """The TotalConnect service is unavailable or unreachable."""
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = build, lint, py37, py38, py39
+envlist = build, lint, py38, py39
 skip_missing_interpreters = True
 skipsdist = True
 


### PR DESCRIPTION
Previously when a user provided an invalid usercode, the BadResultCodeError exception was thrown, but we couldn't differentiate that from other problems.  Adds a new UsercodeInvalid exception to help with handling https://github.com/home-assistant/core/issues/68023.  

Update tests to match.

