### PR TITLE
Update request args after re-authentication

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="total_connect_client",
-    version="2022.5",
+    version="2022.10",
     description="Interact with Total Connect 2 alarm systems",
     author="Craig J. Midwinter",
     author_email="craig.j.midwinter@gmail.com",

--- a/tests/const.py
+++ b/tests/const.py
@@ -212,11 +212,13 @@ RESPONSE_ARMED_AWAY = {
 RESPONSE_AUTHENTICATE = {
     "ResultCode": 0,
     "ResultData": "Success",
-    "SessionID": 1,
+    "SessionID": "12345",
     "Locations": LOCATIONS,
     "ModuleFlags": MODULE_FLAGS,
     "UserInfo": USER,
 }
+
+
 
 RESPONSE_AUTHENTICATE_EMPTY = RESPONSE_AUTHENTICATE.copy()
 RESPONSE_AUTHENTICATE_EMPTY["Locations"] = None
@@ -245,6 +247,7 @@ RESPONSE_CONNECTION_ERROR = {
 RESPONSE_SESSION_INITIATED = {
     "ResultCode": _ResultCode.SESSION_INITIATED.value,
     "ResultData": "testing session initiated",
+    "SessionID": "54321",
 }
 
 RESPONSE_FEATURE_NOT_SUPPORTED = {

--- a/total_connect_client/client.py
+++ b/total_connect_client/client.py
@@ -218,8 +218,10 @@ class TotalConnectClient:
             if attempts_remaining <= 0:
                 raise ServiceUnavailable(f"Invalid Session after multiple retries: {err}") from err
             LOGGER.info(f"reauthenticating {self.username}: {attempts_remaining} retries remaining")
+            old_token = self.token
             self.token = None
             self.authenticate()
+            args = [self.token if old_token == arg else arg for arg in args]
         return self.request(operation_name, args, attempts_remaining)
 
     def authenticate(self):


### PR DESCRIPTION
Ensures we use the new token in request arguments immediately after re-authenticating.

Fixes #189