### PR TITLE
Handle ResponseCode is None

### DIFF
--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -164,3 +164,10 @@ class TestTotalConnectClient(unittest.TestCase):
             with pytest.raises(BadResultCodeError):
                 TotalConnectClient("username", "password", usercodes=None)
             assert mock_request.call_count == 1
+
+    def tests_empty_response_code(self):
+        """Test an empty response code."""
+        # see issue #228
+        from total_connect_client.const import _ResultCode
+        with pytest.raises(ServiceUnavailable):
+            _ResultCode.from_response(None)

--- a/total_connect_client/const.py
+++ b/total_connect_client/const.py
@@ -2,7 +2,7 @@
 
 from enum import Enum
 
-from .exceptions import BadResultCodeError
+from .exceptions import BadResultCodeError, ServiceUnavailable
 
 
 class ArmType(Enum):
@@ -149,6 +149,9 @@ class _ResultCode(Enum):
     def from_response(response_dict):
         try:
             return _ResultCode(response_dict["ResultCode"])
+        except TypeError:
+            # sometimes when there are server issues, it returns empty responses - see issue #228
+            raise ServiceUnavailable(f"Server returned empty response, check server status at {STATUS_URL}") from None
         except ValueError:
             raise BadResultCodeError(
                 f"unknown result code {response_dict['ResultCode']}", response_dict
@@ -178,3 +181,5 @@ class _ResultCode(Enum):
 
 
 PROJECT_URL = "https://github.com/craigjmidwinter/total-connect-client"
+
+STATUS_URL = "https://status.resideo.com/"


### PR DESCRIPTION
When the server is having issues, it sometimes responds with empty (None) responses.  This change checks for that and raises the ServiceUnavailable exception.

Fixes #228 