### PR TITLE
add optional usercode in arm and disarm functions

### DIFF
--- a/total_connect_client/client.py
+++ b/total_connect_client/client.py
@@ -410,26 +410,26 @@ class ArmingHelper:
         """Initialize ArmingHelper."""
         self.armable = partition_or_location
 
-    def arm_away(self) -> None:
+    def arm_away(self, usercode: str = "") -> None:
         """Arm the system (Away)."""
-        self.armable.arm(ArmType.AWAY)
+        self.armable.arm(arm_type=ArmType.AWAY, usercode=usercode)
 
-    def arm_stay(self) -> None:
+    def arm_stay(self, usercode: str = "") -> None:
         """Arm the system (Stay)."""
-        self.armable.arm(ArmType.STAY)
+        self.armable.arm(arm_type=ArmType.STAY, usercode=usercode)
 
-    def arm_stay_instant(self) -> None:
+    def arm_stay_instant(self, usercode: str = "") -> None:
         """Arm the system (Stay - Instant)."""
-        self.armable.arm(ArmType.STAY_INSTANT)
+        self.armable.arm(arm_type=ArmType.STAY_INSTANT, usercode=usercode)
 
-    def arm_away_instant(self) -> None:
+    def arm_away_instant(self, usercode: str = "") -> None:
         """Arm the system (Away - Instant)."""
-        self.armable.arm(ArmType.AWAY_INSTANT)
+        self.armable.arm(arm_type=ArmType.AWAY_INSTANT, usercode=usercode)
 
-    def arm_stay_night(self) -> None:
+    def arm_stay_night(self, usercode: str = "") -> None:
         """Arm the system (Stay - Night)."""
-        self.armable.arm(ArmType.STAY_NIGHT)
+        self.armable.arm(arm_type=ArmType.STAY_NIGHT, usercode=usercode)
 
-    def disarm(self) -> None:
+    def disarm(self, usercode: str = "") -> None:
         """Disarm the system."""
-        self.armable.disarm()
+        self.armable.disarm(usercode=usercode)

--- a/total_connect_client/partition.py
+++ b/total_connect_client/partition.py
@@ -39,13 +39,13 @@ class TotalConnectPartition:
 
         return data
 
-    def arm(self, arm_type: ArmType) -> None:
+    def arm(self, arm_type: ArmType, usercode: str = "") -> None:
         """Arm the partition."""
-        self.parent.arm(arm_type, self.partitionid)
+        self.parent.arm(arm_type, self.partitionid, usercode)
 
-    def disarm(self) -> None:
+    def disarm(self, usercode: str = "") -> None:
         """Disarm the partition."""
-        self.parent.disarm(self.partitionid)
+        self.parent.disarm(self.partitionid, usercode)
 
     def _update(self, info: Dict[str, Any]) -> None:
         """Update partition based on PartitionInfo."""


### PR DESCRIPTION
Adds an optional `usercode` parameter in Location, Partition and ArmingHelper arm and disarm functions.

If usercode is not passed, it uses the already stored usercode from initial setup (which we currently use).  So this is backwards compatible.

Fixes #236
