### PR TITLE
Use alternative ValidateUserCodeEx request for user code validation

### DIFF
--- a/total_connect_client/client.py
+++ b/total_connect_client/client.py
@@ -427,7 +427,10 @@ class TotalConnectClient:
 
     def validate_usercode(self, device_id: str, usercode: str) -> bool:
         """Return True if the usercode is valid for the device."""
-        response = self.request("ValidateUserCode", (self.token, device_id, usercode))
+        response = self.request(
+            "ValidateUserCodeEx",
+            ({"SessionId": self.token, "DeviceId": device_id, "UserCode": usercode}, )
+        )
         try:
             self.raise_for_resultcode(response)
         except UsercodeInvalid:


### PR DESCRIPTION
Related to #245 , seems like the "ValidateUserCode" SOAP request has been deprecated and removed. Use the alternative "ValidateUserCodeEx" request instead, which still seems to be operational.