### PR TITLE
Start using Web API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pycryptodome>=3.21.0
 pyjwt>=2.10.1
+requests-oauthlib>=2.0.0
 zeep>=4.2.1

--- a/tests/common.py
+++ b/tests/common.py
@@ -2,7 +2,6 @@
 from unittest.mock import patch
 
 from const import (
-    RESPONSE_SESSION_DETAILS,
     RESPONSE_DISARMED,
     RESPONSE_GET_ZONE_DETAILS_SUCCESS,
     RESPONSE_PARTITION_DETAILS,
@@ -14,7 +13,6 @@ from total_connect_client.client import TotalConnectClient
 def create_client():
     """Return a TotalConnectClient that appears to be logged in."""
     responses = [
-        RESPONSE_SESSION_DETAILS,
         RESPONSE_PARTITION_DETAILS,
         RESPONSE_GET_ZONE_DETAILS_SUCCESS,
         RESPONSE_DISARMED,
@@ -22,11 +20,9 @@ def create_client():
 
     with patch(
         "total_connect_client.client.TotalConnectClient.request", side_effect=responses
-    ) as mock_request:
+    ):
         mock_client = TotalConnectClient("username", "password", {"123456": "1234"})
-        assert mock_request.call_count == 1
         if mock_client.locations:  # force client to fetch them
             pass
-        assert mock_request.call_count == 4
 
     return mock_client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,14 +6,24 @@ import requests_mock
 from const import (
     HTTP_RESPONSE_CONFIG,
     HTTP_RESPONSE_TOKEN,
+    HTTP_RESPONSE_SESSION_DETAILS
 )
 
-from total_connect_client.client import TotalConnectClient
+from total_connect_client.const import (
+    AUTH_CONFIG_ENDPOINT,
+    AUTH_TOKEN_ENDPOINT,
+    HTTP_API_SESSION_DETAILS_ENDPOINT
+)
 
 @pytest.fixture(autouse=True)
 def mock_http_requests():
     """Automatically mock any direct HTTP requests, right now these are used for authentication only."""
     with requests_mock.Mocker() as rm:
-        rm.get(TotalConnectClient.CONFIG_ENDPOINT, json=HTTP_RESPONSE_CONFIG, status_code=200)
-        rm.post(TotalConnectClient.TOKEN_ENDPOINT, json=HTTP_RESPONSE_TOKEN, status_code=200)
+        rm.get(AUTH_CONFIG_ENDPOINT, json=HTTP_RESPONSE_CONFIG, status_code=200)
+        rm.post(AUTH_TOKEN_ENDPOINT, json=HTTP_RESPONSE_TOKEN, status_code=200)
+        rm.get(
+            HTTP_API_SESSION_DETAILS_ENDPOINT,
+            json=HTTP_RESPONSE_SESSION_DETAILS,
+            status_code=200
+        )
         yield

--- a/tests/const.py
+++ b/tests/const.py
@@ -1,11 +1,10 @@
 """Testing constants."""
 
+import copy
 import jwt
 
 from total_connect_client import ArmingState, ZoneType, ZoneStatus
 from total_connect_client.const import _ResultCode
-
-MAX_RETRY_ATTEMPTS = 10  # default argument to TotalConnectClient.requests()
 
 PASSWORD_BAD = "none"
 USERNAME_BAD = "none"
@@ -28,10 +27,10 @@ LOCATION_INFO_BASIC_NORMAL = {
     "SecurityDeviceID": "987654",
     "PhotoURL": "http://www.example.com/some/path/to/file.jpg",
     "LocationModuleFlags": "Security=1,Video=0,Automation=0,GPS=0,VideoPIR=0",
-    "DeviceList": {"DeviceInfoBasic": DEVICE_LIST},
+    "DeviceList": DEVICE_LIST,
 }
 
-LOCATIONS = {"LocationInfoBasic": [LOCATION_INFO_BASIC_NORMAL]}
+LOCATIONS = [LOCATION_INFO_BASIC_NORMAL]
 
 MODULE_FLAGS = "Some=0,Fake=1,Flags=2"
 
@@ -281,17 +280,19 @@ RESPONSE_PARTITION_DETAILS_TWO = {
     "PartitionsInfoList": PARTITION_DETAILS_TWO,
 }
 
-RESPONSE_SESSION_DETAILS = {
+HTTP_RESPONSE_SESSION_DETAILS = {
     "ResultCode": 0,
     "ResultData": "Success",
-    "SessionID": "12345",
-    "Locations": LOCATIONS,
-    "ModuleFlags": MODULE_FLAGS,
-    "UserInfo": USER,
+    "SessionDetailsResult": {
+        "SessionID": "12345",
+        "Locations": LOCATIONS,
+        "ModuleFlags": MODULE_FLAGS,
+        "UserInfo": USER,
+    }
 }
 
-RESPONSE_SESSION_DETAILS_EMPTY = RESPONSE_SESSION_DETAILS.copy()
-RESPONSE_SESSION_DETAILS_EMPTY["Locations"] = None
+HTTP_RESPONSE_SESSION_DETAILS_EMPTY = copy.deepcopy(HTTP_RESPONSE_SESSION_DETAILS)
+HTTP_RESPONSE_SESSION_DETAILS_EMPTY["SessionDetailsResult"]["Locations"] = None
 
 TCC_REQUEST_METHOD = "total_connect_client.client.TotalConnectClient.request"
 

--- a/tests/test_client_authenticate.py
+++ b/tests/test_client_authenticate.py
@@ -11,8 +11,7 @@ from const import (
     HTTP_RESPONSE_BAD_USER_OR_PASSWORD,
 )
 
-from total_connect_client.const import _ResultCode
-from total_connect_client.client import TotalConnectClient
+from total_connect_client.const import _ResultCode, AUTH_TOKEN_ENDPOINT
 from total_connect_client.exceptions import AuthenticationError
 
 RESPONSE_SUCCESS = {
@@ -74,7 +73,7 @@ class TestTotalConnectClient(unittest.TestCase):
             # bad user or pass
             with requests_mock.Mocker(real_http=True) as rm, pytest.raises(AuthenticationError):
                 rm.post(
-                    TotalConnectClient.TOKEN_ENDPOINT,
+                    AUTH_TOKEN_ENDPOINT,
                     json=HTTP_RESPONSE_BAD_USER_OR_PASSWORD,
                     status_code=403
                 )

--- a/tests/test_client_init.py
+++ b/tests/test_client_init.py
@@ -3,23 +3,23 @@
 from unittest.mock import patch
 
 import pytest
+import requests_mock
 from const import (
-    RESPONSE_SESSION_DETAILS,
-    RESPONSE_SESSION_DETAILS_EMPTY,
+    HTTP_RESPONSE_SESSION_DETAILS_EMPTY,
     RESPONSE_DISARMED,
     RESPONSE_GET_ZONE_DETAILS_SUCCESS,
     RESPONSE_PARTITION_DETAILS,
+    RESPONSE_PARTITION_DETAILS_TWO
 )
 
-from tests.const import RESPONSE_PARTITION_DETAILS_TWO
 from total_connect_client.client import TotalConnectClient
+from total_connect_client.const import HTTP_API_SESSION_DETAILS_ENDPOINT
 from total_connect_client.exceptions import TotalConnectError
 
 
 def tests_init_usercodes_none():
     """Test init with usercodes == None."""
     responses = [
-        RESPONSE_SESSION_DETAILS,
         RESPONSE_PARTITION_DETAILS,
         RESPONSE_GET_ZONE_DETAILS_SUCCESS,
         RESPONSE_DISARMED,
@@ -27,35 +27,28 @@ def tests_init_usercodes_none():
 
     with patch(
         "total_connect_client.client.TotalConnectClient.request", side_effect=responses
-    ) as mock_request:
+    ):
         mock_client = TotalConnectClient("username", "password", usercodes=None)
-        assert mock_request.call_count == 1
-        if mock_client.locations:  # force client to fetch them
-            pass
-        assert mock_request.call_count == 4
 
     assert not mock_client.usercodes
 
 
 def tests_init_locations_empty():
     """Test init with no locations."""
-    responses = [
-        RESPONSE_SESSION_DETAILS_EMPTY,
-    ]
-
-    with patch(
-        "total_connect_client.client.TotalConnectClient.request", side_effect=responses
-    ) as mock_request, pytest.raises(TotalConnectError):
+    with requests_mock.Mocker(real_http=True) as rm, pytest.raises(TotalConnectError):
+        rm.get(
+            HTTP_API_SESSION_DETAILS_ENDPOINT,
+            json=HTTP_RESPONSE_SESSION_DETAILS_EMPTY,
+            status_code=200
+        )
 
         mock_client = TotalConnectClient("username", "password", usercodes=None)
         assert mock_client.locations == {}
-        assert mock_request.call_count == 1
 
 
 def tests_init_usercodes_string():
     """Test init with usercodes == a string."""
     responses = [
-        RESPONSE_SESSION_DETAILS,
         RESPONSE_PARTITION_DETAILS,
         RESPONSE_GET_ZONE_DETAILS_SUCCESS,
         RESPONSE_DISARMED,
@@ -73,7 +66,6 @@ def tests_init_partitions():
     """Test that partitions populate correctly."""
     # one partition
     responses = [
-        RESPONSE_SESSION_DETAILS,
         RESPONSE_PARTITION_DETAILS,
         RESPONSE_GET_ZONE_DETAILS_SUCCESS,
         RESPONSE_DISARMED,
@@ -81,18 +73,15 @@ def tests_init_partitions():
 
     with patch(
         "total_connect_client.client.TotalConnectClient.request", side_effect=responses
-    ) as mock_request:
+    ):
         mock_client = TotalConnectClient("username", "password", usercodes=None)
-        assert mock_request.call_count == 1
         if mock_client.locations:  # force client to fetch them
             pass
-        assert mock_request.call_count == 4
 
         assert len(mock_client.locations["123456"].partitions) == 1
 
     # two partitions
     responses = [
-        RESPONSE_SESSION_DETAILS,
         RESPONSE_PARTITION_DETAILS_TWO,
         RESPONSE_GET_ZONE_DETAILS_SUCCESS,
         RESPONSE_DISARMED,
@@ -100,11 +89,9 @@ def tests_init_partitions():
 
     with patch(
         "total_connect_client.client.TotalConnectClient.request", side_effect=responses
-    ) as mock_request:
+    ):
         mock_client = TotalConnectClient("username", "password", usercodes=None)
-        assert mock_request.call_count == 1
         if mock_client.locations:  # force client to fetch them
             pass
-        assert mock_request.call_count == 4
 
         assert len(mock_client.locations["123456"].partitions) == 2

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -2,15 +2,16 @@
 
 import unittest
 from unittest.mock import patch
+
+import requests
 from zeep.exceptions import Fault as ZeepFault
+from oauthlib.oauth2 import OAuth2Error, TokenExpiredError
 
 import pytest
 import requests_mock
 from const import (
-    MAX_RETRY_ATTEMPTS,
     LOCATION_INFO_BASIC_NORMAL,
     RESPONSE_ARMED_AWAY,
-    RESPONSE_SESSION_DETAILS,
     RESPONSE_CONNECTION_ERROR,
     RESPONSE_DISARMED,
     RESPONSE_FAILED_TO_CONNECT,
@@ -21,17 +22,18 @@ from const import (
     HTTP_RESPONSE_TOKEN,
     HTTP_RESPONSE_TOKEN_2,
     HTTP_RESPONSE_BAD_USER_OR_PASSWORD,
-    HTTP_RESPONSE_REFRESH_TOKEN_FAILED,
     SESSION_ID,
     SESSION_ID_2,
-    TOKEN_EXPIRATION_TIME
 )
 
-from total_connect_client.const import ArmType
+from total_connect_client.const import ArmType, AUTH_TOKEN_ENDPOINT, _ResultCode
 from total_connect_client.client import TotalConnectClient
-from total_connect_client.exceptions import AuthenticationError, BadResultCodeError, ServiceUnavailable
-
-PATCH_EVAL = "total_connect_client.client.TotalConnectClient._send_one_request"
+from total_connect_client.exceptions import (
+    AuthenticationError,
+    BadResultCodeError,
+    RetryableTotalConnectError,
+    ServiceUnavailable
+)
 
 
 class TestTotalConnectClient(unittest.TestCase):
@@ -49,27 +51,24 @@ class TestTotalConnectClient(unittest.TestCase):
     def tests_request_init(self):
         """Test normal init sequence with no problems."""
         serialize_responses = [
-            RESPONSE_SESSION_DETAILS,
             RESPONSE_PARTITION_DETAILS,
             RESPONSE_GET_ZONE_DETAILS_SUCCESS,
             RESPONSE_DISARMED,
         ]
 
         with patch("zeep.Client"), patch(
-            PATCH_EVAL, side_effect=serialize_responses
-        ) as mock_request:
+            "zeep.helpers.serialize_object", side_effect=serialize_responses
+        ):
             client = TotalConnectClient("username", "password", usercodes=None)
-            assert mock_request.call_count == 1
             if client.locations:  # force client to fetch them
                 pass
-            assert mock_request.call_count == 4
             assert client.is_logged_in() is True
 
     def tests_request_init_bad_user_or_password(self):
-        """Test init sequence with no a bad password."""
+        """Test init sequence with a bad password."""
         with requests_mock.Mocker(real_http=True) as rm:
             rm.post(
-                TotalConnectClient.TOKEN_ENDPOINT,
+                AUTH_TOKEN_ENDPOINT,
                 json=HTTP_RESPONSE_BAD_USER_OR_PASSWORD,
                 status_code=403
             )
@@ -79,57 +78,117 @@ class TestTotalConnectClient(unittest.TestCase):
     def tests_request_init_failed_to_connect(self):
         """Test init sequence when it fails to connect."""
         serialize_responses = [
-            RESPONSE_FAILED_TO_CONNECT for x in range(MAX_RETRY_ATTEMPTS)
+            RESPONSE_FAILED_TO_CONNECT for x in range(TotalConnectClient.MAX_RETRY_ATTEMPTS)
         ]
 
+        # Patch the SOAP client so that it raises a connection error
         with patch("zeep.Client"), patch("time.sleep", autospec=True), patch(
-            PATCH_EVAL, side_effect=serialize_responses
-        ) as mock_request, pytest.raises(Exception) as exc:
+            "zeep.helpers.serialize_object", side_effect=serialize_responses
+        ) as mock_request:
             client = TotalConnectClient(
                 "username", "password", usercodes=None, retry_delay=0
             )
-            assert mock_request.call_count == MAX_RETRY_ATTEMPTS
-            assert client.is_logged_in() is False
-            expected = "total-connect-client could not execute request.  Maximum attempts tried."
-            assert str(exc.value) == expected
+
+            # Force client to fetch all locations
+            with pytest.raises(RetryableTotalConnectError) as exc:
+                if client.locations:
+                    pass
+
+            assert mock_request.call_count == TotalConnectClient.MAX_RETRY_ATTEMPTS
+            assert "failed to connect with panel" in str(exc.value)
 
     def tests_request_connection_error(self):
         """Test a connection error."""
         serialize_responses = [
-            RESPONSE_CONNECTION_ERROR for x in range(MAX_RETRY_ATTEMPTS)
+            RESPONSE_CONNECTION_ERROR for x in range(TotalConnectClient.MAX_RETRY_ATTEMPTS)
         ]
 
+        # Patch the SOAP client so that it raises a connection error
         with patch("zeep.Client"), patch("time.sleep", autospec=True), patch(
             "zeep.helpers.serialize_object", side_effect=serialize_responses
-        ) as mock_request, pytest.raises(Exception) as exc:
+        ) as mock_request:
             client = TotalConnectClient(
                 "username", "password", usercodes=None, retry_delay=0
             )
-            assert mock_request.call_count == MAX_RETRY_ATTEMPTS
-            assert client.is_logged_in() is False
-            expected = "total-connect-client could not execute request.  Maximum attempts tried."
-            assert str(exc.value) == expected
+
+            # Make a SOAP request
+            with pytest.raises(RetryableTotalConnectError) as exc:
+                client.request("Test", (client.token,))
+
+            assert mock_request.call_count == TotalConnectClient.MAX_RETRY_ATTEMPTS
+            assert "connection error" in str(exc.value)
 
     def tests_request_zeep_error(self):
         """Test a Zeep error."""
 
-        serialize_responses = [ZeepFault("test") for x in range(MAX_RETRY_ATTEMPTS)]
+        # Patch the SOAP client so that it raises an internal exception
+        serialize_responses = [ZeepFault("test") for x in range(TotalConnectClient.MAX_RETRY_ATTEMPTS)]
         with patch("zeep.Client"), patch("time.sleep", autospec=True), patch(
             "zeep.helpers.serialize_object", side_effect=serialize_responses
-        ) as mock_request, pytest.raises(ServiceUnavailable):
+        ) as mock_request:
             client = TotalConnectClient(
                 "username", "password", usercodes=None, retry_delay=0
             )
-            assert mock_request.call_count == MAX_RETRY_ATTEMPTS
-            assert client.is_logged_in() is False
+
+            # Make a SOAP request
+            with pytest.raises(ServiceUnavailable):
+                client.request("Test", (client.token,))
+
+            # Check that the call was tried the correct number of times
+            assert mock_request.call_count == TotalConnectClient.MAX_RETRY_ATTEMPTS
+
+    def tests_http_retryable_error(self):
+        """Test a retryable API error recieved via HTTP."""
+
+        client = TotalConnectClient(
+            "username", "password", usercodes=None, retry_delay=0
+        )
+
+        with requests_mock.Mocker() as rm:
+            mock_request = rm.get(
+                "https://api/test",
+                json=RESPONSE_CONNECTION_ERROR,
+                status_code=502
+            )
+
+            # Make an HTTP Request and check that we get the correct exception from the
+            # library.
+            with pytest.raises(RetryableTotalConnectError):
+                client.http_request(
+                    endpoint="https://api/test",
+                    method="GET"
+                )
+
+            # Check that the call was tried the correct number of times
+            assert mock_request.call_count == TotalConnectClient.MAX_RETRY_ATTEMPTS
+
+    def tests_http_request_error(self):
+        """Test an HTTP Error."""
+
+        client = TotalConnectClient(
+            "username", "password", usercodes=None, retry_delay=0
+        )
+
+        with requests_mock.Mocker() as rm:
+            mock_request = rm.get("https://api/test", exc=requests.RequestException)
+
+            # Make an HTTP Request and check that we get the correct exception from the
+            # library.
+            with pytest.raises(ServiceUnavailable):
+                client.http_request(
+                    endpoint="https://api/test",
+                    method="GET"
+                )
+
+            # Check that the call was tried the correct number of times
+            assert mock_request.call_count == TotalConnectClient.MAX_RETRY_ATTEMPTS
 
     def tests_request_invalid_session(self):
         """Test an invalid session, which is when the session times out."""
-        # First four responses set up 'normal' session
+        # First responses set up 'normal' session
         # Call to client.arm_away() will first get an invalid session,
         # which will trigger client.authenticate() before completing the arm_away()
         serialize_responses = [
-            RESPONSE_SESSION_DETAILS,
             RESPONSE_PARTITION_DETAILS,
             RESPONSE_GET_ZONE_DETAILS_SUCCESS,
             RESPONSE_DISARMED,
@@ -143,14 +202,12 @@ class TestTotalConnectClient(unittest.TestCase):
         ]
 
         with patch("zeep.Client"), patch(
-            PATCH_EVAL, side_effect=serialize_responses
-        ) as mock_request, requests_mock.Mocker(real_http=True) as rm:
-            rm.post(TotalConnectClient.TOKEN_ENDPOINT, token_responses)
+            "zeep.helpers.serialize_object", side_effect=serialize_responses
+        ), requests_mock.Mocker(real_http=True) as rm:
+            rm.post(AUTH_TOKEN_ENDPOINT, token_responses)
             client = TotalConnectClient("username", "password", usercodes=None)
-            assert mock_request.call_count == 1
             if client.locations:  # force client to fetch them
                 pass
-            assert mock_request.call_count == 4
             assert client.is_logged_in() is True
 
             assert client.token == SESSION_ID
@@ -158,26 +215,17 @@ class TestTotalConnectClient(unittest.TestCase):
             # the invalid session will trigger a new authenticate()...
             # which should result in a new token
             client.locations[LOCATION_INFO_BASIC_NORMAL["LocationID"]].arm(ArmType.AWAY)
-            assert mock_request.call_count == 6
             assert client.token == SESSION_ID_2
 
     def tests_request_unknown_result_code(self):
         """Test an unknown result code."""
-        serialize_responses = [
-            RESPONSE_UNKNOWN,
-        ]
+        with pytest.raises(BadResultCodeError):
+            _ResultCode.from_response(RESPONSE_UNKNOWN)
 
-        with patch("zeep.Client"), patch(
-            PATCH_EVAL, side_effect=serialize_responses
-        ) as mock_request:
-            with pytest.raises(BadResultCodeError):
-                TotalConnectClient("username", "password", usercodes=None)
-            assert mock_request.call_count == 1
 
     def tests_empty_response_code(self):
         """Test an empty response code."""
         # see issue #228
-        from total_connect_client.const import _ResultCode
         with pytest.raises(ServiceUnavailable):
             _ResultCode.from_response(None)
 
@@ -185,11 +233,10 @@ class TestTotalConnectClient(unittest.TestCase):
         """Test various scenarious around session refreshing. First the session expires and is
         successfully refreshed, then the session expires and the refresh fails, forcing a full
         reauthentication"""
-        # First four responses set up 'normal' session
+        # First responses set up 'normal' session
         # Call to client.arm_away() will first require a session refresh
         # Call to client.disarm() will first require a session refresh
         serialize_responses = [
-            RESPONSE_SESSION_DETAILS,
             RESPONSE_PARTITION_DETAILS,
             RESPONSE_GET_ZONE_DETAILS_SUCCESS,
             RESPONSE_DISARMED,
@@ -197,86 +244,52 @@ class TestTotalConnectClient(unittest.TestCase):
             RESPONSE_DISARMED
         ]
 
-        # Mocked values for 'time.monotonic'
-        mock_times = [
-            # Time for initial authentication
-            0,
-
-            # Session still valid before RESPONSE_SESSION_DETAILS
-            TOKEN_EXPIRATION_TIME - 5,
-
-            # Session still valid before RESPONSE_PARTITION_DETAILS
-            TOKEN_EXPIRATION_TIME - 4,
-
-            # Session still valid before RESPONSE_GET_ZONE_DETAILS_SUCCESS
-            TOKEN_EXPIRATION_TIME - 3,
-
-            # Session still valid before RESPONSE_DISARMED
-            TOKEN_EXPIRATION_TIME - 2,
-
-            # Session expires before RESPONSE_ARMED_AWAY
-            TOKEN_EXPIRATION_TIME,
-
-            # Time for session refresh
-            TOKEN_EXPIRATION_TIME,
-
-            # Session expires before RESPONSE_DISARMED
-            TOKEN_EXPIRATION_TIME * 2,
-
-            # Time for reauthentication
-            TOKEN_EXPIRATION_TIME * 2,
-
-            # Session now valid for RESPONSE_DISARMED
-            TOKEN_EXPIRATION_TIME * 2 + 1,
-        ]
-
-        token_responses = [
-            # Successful response for initial authentication
-            {"json": HTTP_RESPONSE_TOKEN, "status_code": 200},
-
-            # Successful response for session refresh
-            {"json": HTTP_RESPONSE_TOKEN, "status_code": 200},
-
-            # Failed response for refresh
-            {"json": HTTP_RESPONSE_REFRESH_TOKEN_FAILED, "status_code": 400},
-
-            # Successful response for reauthentication
-            {"json": HTTP_RESPONSE_TOKEN_2, "status_code": 200},
-        ]
-
         with patch("zeep.Client"), patch(
-            PATCH_EVAL, side_effect=serialize_responses
-        ) as mock_request, patch(
-            "time.monotonic", side_effect=mock_times
-        ), requests_mock.Mocker(real_http=True) as rm:
-            rm.post(TotalConnectClient.TOKEN_ENDPOINT, token_responses)
+            "zeep.helpers.serialize_object", side_effect=serialize_responses
+        ), patch(
+            "total_connect_client.client.LegacyApplicationClient",
+            autospec=True
+        ) as mock_oauth_client_class, patch(
+            "total_connect_client.client.OAuth2Session",
+            autospec=True
+        ) as mock_oauth_session_class:
+            mock_oauth_client = mock_oauth_client_class.return_value
+            mock_oauth_session = mock_oauth_session_class.return_value
 
+            # Pass HTTP requests through to our mocked requests library
+            mock_oauth_session.request.side_effect = requests.request
+
+            # Test initial authentication
+            mock_oauth_session.access_token = HTTP_RESPONSE_TOKEN["access_token"].encode()
             client = TotalConnectClient("username", "password", usercodes=None)
-            assert mock_request.call_count == 1
             if client.locations:  # force client to fetch them
                 pass
-            assert mock_request.call_count == 4
             assert client.is_logged_in() is True
             assert client.token == SESSION_ID
+            mock_oauth_session.fetch_token.assert_called_once()
+            mock_oauth_session.refresh_token.reset_mock()
+            mock_oauth_session.fetch_token.reset_mock()
 
-            # The session should come up as expired due to the current time.
+            # The session should come up as expired due to the TokenExpiredError.
             # The client refreshes the session and should get the same session id.
+            mock_oauth_client.add_token.side_effect = [TokenExpiredError, None]
             client.locations[LOCATION_INFO_BASIC_NORMAL["LocationID"]].arm(ArmType.AWAY)
-            assert mock_request.call_count == 5
             assert client.token == SESSION_ID
 
-            # Check that we made a refresh session request
-            last_http_request = rm.request_history[-1]
-            assert last_http_request.url == TotalConnectClient.TOKEN_ENDPOINT
-            assert "grant_type=refresh_token" in last_http_request.text
+            # Check that we refreshed but did not reauthenticate
+            mock_oauth_session.refresh_token.assert_called_once()
+            mock_oauth_session.fetch_token.assert_not_called()
+            mock_oauth_session.refresh_token.reset_mock()
+            mock_oauth_session.fetch_token.reset_mock()
 
-            # The session should come up as expired again due to the current time.
+            # The session should come up as expired again due to the TokenExpiredError.
             # The session refresh fails so we reauthenticate and get a new session.
+            mock_oauth_session.refresh_token.side_effect = OAuth2Error
+            mock_oauth_client.add_token.side_effect = [TokenExpiredError, None]
+            mock_oauth_session.access_token = HTTP_RESPONSE_TOKEN_2["access_token"].encode()
             client.locations[LOCATION_INFO_BASIC_NORMAL["LocationID"]].disarm()
-            assert mock_request.call_count == 6
             assert client.token == SESSION_ID_2
 
-            # Check that we made an authentication request
-            last_http_request = rm.request_history[-1]
-            assert last_http_request.url == TotalConnectClient.TOKEN_ENDPOINT
-            assert "grant_type=password" in last_http_request.text
+            # Check that we refreshed and reauthenticated
+            mock_oauth_session.refresh_token.assert_called_once()
+            mock_oauth_session.fetch_token.assert_called_once()

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -380,4 +380,3 @@ def test_bypass():
     zone = tcz(zone_data, location)
     zone.bypass()
     location.zone_bypass.assert_called_once()
-

--- a/total_connect_client/const.py
+++ b/total_connect_client/const.py
@@ -2,6 +2,7 @@
 
 from enum import Enum
 from typing import Dict, Any
+import urllib.parse
 
 from .exceptions import BadResultCodeError, ServiceUnavailable
 
@@ -202,3 +203,11 @@ class _ResultCode(Enum):
 PROJECT_URL = "https://github.com/craigjmidwinter/total-connect-client"
 
 STATUS_URL = "https://status.resideo.com/"
+
+SOAP_API_ENDPOINT = "https://rs.alarmnet.com/TC21api/tc2.asmx?WSDL"
+AUTH_CONFIG_ENDPOINT = "https://totalconnect2.com/application.config.json"
+AUTH_TOKEN_ENDPOINT = "https://rs.alarmnet.com/TC2API.Auth/token"
+HTTP_API_ENDPOINT_BASE = "https://rs.alarmnet.com/TC2API.TCResource/"
+def _make_http_endpoint(path: str) -> str:
+    return urllib.parse.urljoin(HTTP_API_ENDPOINT_BASE, path)
+HTTP_API_SESSION_DETAILS_ENDPOINT = _make_http_endpoint("api/v3/authentication/sessiondetails")

--- a/total_connect_client/device.py
+++ b/total_connect_client/device.py
@@ -19,7 +19,7 @@ class TotalConnectDevice:
         self._unicorn_info: Dict[str, Any] = {}
 
         flags = info.get("DeviceFlags")
-        if flags is None:
+        if not flags:
             self.flags = {}
         else:
             self.flags = dict(x.split("=") for x in flags.split(","))

--- a/total_connect_client/location.py
+++ b/total_connect_client/location.py
@@ -45,8 +45,8 @@ class TotalConnectLocation:
         self._sync_job_id = None
         self._sync_job_state: int = 0
 
-        dib = (location_info_basic.get("DeviceList") or {}).get("DeviceInfoBasic")
-        tcdevs = [TotalConnectDevice(d) for d in (dib or {})]
+        dib = location_info_basic.get("DeviceList") or []
+        tcdevs = [TotalConnectDevice(d) for d in dib]
         self.devices = {tcdev.deviceid: tcdev for tcdev in tcdevs}
 
     def __str__(self) -> str:


### PR DESCRIPTION
Ref: #245 

Add functions to call the HTTP Web API, and switch over the SessionDetails request performed during login from SOAP to HTTP. To make a Web API request, use the `TotalConnectClient.http_request` function, only one call was switched here but this should make it straightforward to switch others in the future.

Other changes:
 - I switched the ad-hoc OAuth2 implementation added in #243 to use `requests-oauthlib` instead. This library will refresh the session automatically if making HTTP requests. For now we still need some manual refresh code to handle the SOAP cases, but this can be removed eventually (along with the entire `request` function)
 - The tests are somewhat simplified. Many of them were counting exact calls to SOAP, but now that requests are switching from HTTP -> SOAP this counting becomes difficult.

I tested this against my system, it is able to load all the session details with a few minor differences. Not sure if these should be tracked down:
```
$ diff old.log new.log
32c32
< PhotoURL: None
---
> PhotoURL: 
87c87
<   Security Panel Type ID: None
---
>   Security Panel Type ID: 2
```