### PR TITLE
Add experimental trigger panel function

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,14 +17,7 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "pip3 install --user -r requirements.txt",
-
-	// Configure tool-specific properties.
-	// "customizations": {},
-
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+	"postCreateCommand": "pip install .",
 
   "customizations": {
     "vscode": {

--- a/total_connect_client/live/trigger.py
+++ b/total_connect_client/live/trigger.py
@@ -1,0 +1,31 @@
+"""Test your system from the command line."""
+
+import getpass
+import logging
+import sys
+
+from ..client import TotalConnectClient
+
+logging.basicConfig(filename="test.log", level=logging.DEBUG)
+
+
+def usage():
+    """Print usage instructions."""
+    print("usage:  username\n")
+    sys.exit()
+
+
+if len(sys.argv) != 2:
+    usage()
+
+USERNAME = sys.argv[1]
+PASSWORD = getpass.getpass()
+
+TC = TotalConnectClient(USERNAME, PASSWORD)
+
+print("authenticated with Total Connect")
+for location_id in TC.locations:
+    print(f"attempting to trigger location {location_id}")
+    TC.locations[location_id].trigger()
+
+sys.exit()

--- a/total_connect_client/location.py
+++ b/total_connect_client/location.py
@@ -513,3 +513,15 @@ class TotalConnectLocation:
             id = video["DeviceID"]
             if id in self.devices:
                 self.devices[id].video_info = video
+
+    def trigger(self) -> None:
+        """Trigger the alarm (experimental)."""
+        result = self.parent.http_request(
+            endpoint=make_http_endpoint(
+                f"api/v1/locations/{self.location_id}/devices/{self.security_device_id}/RemotePanicAlarm"
+            ),
+            method="POST",
+        )
+        LOGGER.debug(f"trigger result:\n{result}")
+        self.parent.raise_for_resultcode(result)
+        LOGGER.info(f"Triggered alarm at {self.location_id}")


### PR DESCRIPTION
The new API has a call for RemotePanicAlarm.  Added an experimental call to see if this could trigger the alarm panel via code.

Collecting results in https://github.com/craigjmidwinter/total-connect-client/issues/259