### PR TITLE
Model info for HA

### DIFF
--- a/docs/DEVICES.md
+++ b/docs/DEVICES.md
@@ -2,40 +2,42 @@
 
 Information on devices found through testing.
 
-Real Device | DeviceName | DeviceClassID | PanelType | PanelVariant | SecurityPanelTypeID | Notes
------------- | - | - | - | - | - | -
-Vista-21IP | Security Panel | 1 | 2 | 1 | None | #36
-Lynx Plus | Security Panel | 1 | 5 | 1 | None | # 66
-Lynx Touch 7000 | ILP5 | 1 | 8 | 0 | None |
-Lynx Touch 5210 | ILP5 | 1 | 8 | 1 | None | # 85
-LCP500-L | Security System | ? | 10 | 1 | null | # 163
-ProA7Plus | Security System | 1 | 12 | 1 | None | 
-ProA7Plus Z-Wave | Automation  | 3 | None | None | None | #213
-ProA7Plus camera | Built-In Camera  | 6 | None | None | None | #213
-Skybell HD | WiFi DoorBell | 7 | not returned | not returned | None | 
-MyQ Garage Door | Garage Door | 303 | None | None | None | #213
+| Real Device      | DeviceName      | DeviceClassID | PanelType    | PanelVariant | SecurityPanelTypeID | Notes |
+| ---------------- | --------------- | ------------- | ------------ | ------------ | ------------------- | ----- |
+| Vista-21IP       | Security Panel  | 1             | 2            | 1            | None                | # 36  |
+| Lynx Plus        | Security Panel  | 1             | 5            | 1            | None                | # 66  |
+| Lynx Touch 7000  | ILP5            | 1             | 8            | 0            | None                |       |
+| Lynx Touch 5210  | ILP5            | 1             | 8            | 1            | None                | # 85  |
+| LCP500-L         | Security System | ?             | 10           | 1            | null                | # 163 |
+| ProA7Plus        | Security System | 1             | 12           | 1            | 12                  |       |
+| Vista            | LTEM-PV/PIV     | 1             | 15           | 1            | 15                  | # 264 |
+| ProA7Plus Z-Wave | Automation      | 3             | None         | None         | None                | # 213 |
+| ProA7Plus camera | Built-In Camera | 6             | None         | None         | None                | # 213 |
+| Skybell HD       | WiFi DoorBell   | 7             | not returned | not returned | None                |       |
+| MyQ Garage Door  | Garage Door     | 303           | None         | None         | None                | # 213 |
 
 ## Device calls
-Device | GetAutomationDeviceStatus | GetAutomationDeviceStatusExV1 | GetAllAutomationDeviceStatusExV1 | GetSceneList | GetDeviceStatus | Notes
------------- | - | - | - | - | - | -
-Device 6485747 (Security System) | -12104 |  -12104 | -12104 | 0 | 0 | 
-Device 6485748 (Automation) | -12104 | -12104 | -12104 | 0 | 0 | 
-Device 6485749 (Built-In Camera) | -4004 | -4004 | -4004 | 0 | 0 | 
-Device 222896 (Front Lock) | -4002 | -4002 | -4002 | -4002 | 0 | 
-Device 452185 (Garage Door) | -4002 | -4002 | -4002 | -4002 | 0 | 
-Device 6485914 (FRONT DOOR) | -4004 | -4004 | -4004 | 0 | 0 | 
-Skybell HD | -4004 | -4004 | -4004 | 0 | 0 | @austinmroczek
-ProA7Plus Built-In Camera | -4004 | -4004 | -4004 | 0 | 0 | @austinmroczek
-ProA7Plus | -12104 |  -12104 | -12104 | 0 | 0 | @austinmroczek
+
+| Device                           | GetAutomationDeviceStatus | GetAutomationDeviceStatusExV1 | GetAllAutomationDeviceStatusExV1 | GetSceneList | GetDeviceStatus | Notes          |
+| -------------------------------- | ------------------------- | ----------------------------- | -------------------------------- | ------------ | --------------- | -------------- |
+| Device 6485747 (Security System) | -12104                    | -12104                        | -12104                           | 0            | 0               |
+| Device 6485748 (Automation)      | -12104                    | -12104                        | -12104                           | 0            | 0               |
+| Device 6485749 (Built-In Camera) | -4004                     | -4004                         | -4004                            | 0            | 0               |
+| Device 222896 (Front Lock)       | -4002                     | -4002                         | -4002                            | -4002        | 0               |
+| Device 452185 (Garage Door)      | -4002                     | -4002                         | -4002                            | -4002        | 0               |
+| Device 6485914 (FRONT DOOR)      | -4004                     | -4004                         | -4004                            | 0            | 0               |
+| Skybell HD                       | -4004                     | -4004                         | -4004                            | 0            | 0               | @austinmroczek |
+| ProA7Plus Built-In Camera        | -4004                     | -4004                         | -4004                            | 0            | 0               | @austinmroczek |
+| ProA7Plus                        | -12104                    | -12104                        | -12104                           | 0            | 0               | @austinmroczek |
 
 "GetDeviceStatus" always returns success but DeviceInfo = None
 
 ## Camera stuff
 
-Device | GetAllRSIDeviceStatus | GetLocationAllCameraList | GetLocationAllCameraListEx | GetLocationCameraList | GetPartnerCameraStatus | GetVideoPIRLocationDeviceList
------------- | - | - | - | - | - | -
-Skybell HD | No | WiFiDoorbellList | WifiDoorbellList | No | wifidoorbellinfo | No
-ProA7Plus builtin | No | No | No | No | No | VideoPIRInfo
+| Device            | GetAllRSIDeviceStatus | GetLocationAllCameraList | GetLocationAllCameraListEx | GetLocationCameraList | GetPartnerCameraStatus | GetVideoPIRLocationDeviceList |
+| ----------------- | --------------------- | ------------------------ | -------------------------- | --------------------- | ---------------------- | ----------------------------- |
+| Skybell HD        | No                    | WiFiDoorbellList         | WifiDoorbellList           | No                    | wifidoorbellinfo       | No                            |
+| ProA7Plus builtin | No                    | No                       | No                         | No                    | No                     | VideoPIRInfo                  |
 
 GetLocationCameraList doesn't return anything
 GetLocationAllCameraList returns same as GetLocationAllCameraListEx

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -15,3 +15,17 @@ def tests_panel():
     panel = TotalConnectDevice(device_list[0])
     assert panel.deviceid == SECURITY_DEVICE_ID
     assert panel.is_doorbell() is False
+
+
+def tests_model():
+    """Test model info."""
+    panel = TotalConnectDevice(device_list[0])
+    model, model_id = panel.model_info()
+    assert model == "ProA7"
+    assert model_id == "Plus"
+
+    # unknown info
+    panel.class_id = 666
+    model, model_id = panel.model_info()
+    assert model == "Unknown model"
+    assert model_id == "Unknown model ID"

--- a/total_connect_client/device.py
+++ b/total_connect_client/device.py
@@ -1,6 +1,28 @@
 """Total Connect Device."""
 
-from typing import Any
+import logging
+from typing import Any, Final
+
+from .const import PROJECT_URL
+
+LOGGER: Final = logging.getLogger(__name__)
+
+"""
+Leverages data collected from the wild and stored in docs/DEVICES.md
+(DeviceClassID, PanelType, PanelVariant) gives ["Model", "Model ID"]
+"""
+MODEL_LOOKUP = {
+    (0, 0, 0): ["Unknown model", "Unknown model ID"],
+    (1, 2, 1): ["Vista", "21IP"],
+    (1, 5, 1): ["Lynx Plus", "L3000"],
+    (1, 8, 0): ["Lynx Touch", "L7000"],
+    (1, 8, 1): ["Lynx Touch", "L5210"],
+    (1, 10, 1): ["Lyric", "LCP500-L"],
+    (1, 12, 1): ["ProA7", "Plus"],
+    (1, 15, 1): ["Vista", "LTEM-PV/PIV"],
+    (7, 0, 0): ["Skybell", "HD"],
+    (303, 0, 0): ["Chamerlain", "MyQ"],
+}
 
 
 class TotalConnectDevice:
@@ -10,7 +32,7 @@ class TotalConnectDevice:
         """Initialize device based on DeviceInfoBasic."""
         self.deviceid = info.get("DeviceID")
         self.name = info.get("DeviceName")
-        self.class_id = info.get("DeviceClassID")
+        self.class_id: int = int(info.get("DeviceClassID", 0))
         self.serial_number = info.get("DeviceSerialNumber")
         self.security_panel_type_id = info.get("SecurityPanelTypeID")
         self.serial_text = info.get("DeviceSerialText")
@@ -23,6 +45,9 @@ class TotalConnectDevice:
             self.flags = {}
         else:
             self.flags = dict(x.split("=") for x in flags.split(","))
+
+        self._panel_type: int = int(self.flags.get("PanelType", 0))
+        self._panel_variant: int = int(self.flags.get("PanelVariant", 0))
 
     def __str__(self) -> str:  # pragma: no cover
         """Return a string that is printable."""
@@ -49,6 +74,10 @@ class TotalConnectDevice:
         data = data + "  UnicornInfo:\n"
         for key, value in self._unicorn_info.items():
             data = data + f"    {key}: {value}\n"
+
+        model, model_id = self.model_info()
+        data = data + f"  Model: {model}"
+        data = data + f"  Model ID: {model_id}"
 
         return data
 
@@ -94,3 +123,22 @@ class TotalConnectDevice:
         """Set values based on UnicornInfo object."""
         if data:
             self._unicorn_info = data
+
+    def model_info(self) -> tuple[str, str]:
+        """Return device model and ID.
+
+        Used in Home Assistant.
+        https://developers.home-assistant.io/blog/2024/07/16/device-info-model-id/
+
+        """
+        try:
+            model, model_id = MODEL_LOOKUP[(self.class_id, self._panel_type, self._panel_variant)]
+        except KeyError:
+            LOGGER.warning(
+                f"Unknown TotalConnect model info: (DeviceClassID {self.class_id}, "
+                f"PanelType {self._panel_type}, PanelVariant {self._panel_variant}). "
+                f"Please report at {PROJECT_URL}/issues"
+            )
+            model, model_id = "Unknown model", "Unknown model ID"
+
+        return model, model_id


### PR DESCRIPTION
Adds a lookup function in device.py to map panel model (e.g. "Lynx Touch") and model ID ("L7000") for use in Home Assistant.

